### PR TITLE
Oclif4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,11 +28,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -43,7 +43,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -57,4 +57,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,9 @@ jobs:
     steps:
       - name: Post to a Slack channel
         id: slack
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook-type: incoming-webhook
           payload: |
             {
             "text": "New release ${{github.ref_name}} for ${{github.event.repository.name}}.",

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [ main, beta, prerelease ]
+    branches: [ main, beta, prerelease, oclif4 ]
   pull_request:
     branches: [ main ]
 jobs:
@@ -12,16 +12,16 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: latest
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           cache: 'pnpm'

--- a/.releaserc
+++ b/.releaserc
@@ -5,7 +5,8 @@
 		{ "name": "main", "channel": "latest" },
 		"+([0-9])?(.{+([0-9]),x}).x",
 		{ "name": "beta", "prerelease": true },
-		{ "name": "prerelease", "prerelease": "rc" }
+		{ "name": "prerelease", "prerelease": "rc" },
+		{ "name": "oclif", "prerelease": true }
 	],
 	"plugins": [
 		"@semantic-release/commit-analyzer",

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ USAGE
 
 ARGUMENTS
   RESOURCE  the resource type
-  ID        id of the resource to delete
+  [ID]      id of the resource to delete
 
 FLAGS
   -H, --headers       show response headers
@@ -138,8 +138,8 @@ USAGE
 
 ARGUMENTS
   RESOURCE  the resource type
-  ID        id of the resource on which to execute the action
-  ACTION    action to execute on resource
+  [ID]      id of the resource on which to execute the action
+  [ACTION]  action to execute on resource
 
 FLAGS
   -a, --attribute=<value>...  define a resource attribute
@@ -173,7 +173,7 @@ USAGE
 ARGUMENTS
   RESOURCE...  the resource type
   PATH...      path (or URL) of the resource(s) to fetch
-  ID...        resource id
+  [ID...]      resource id
 
 FLAGS
   -H, --headers             show response headers
@@ -228,7 +228,7 @@ USAGE
 
 ARGUMENTS
   RESOURCE...  the resource type
-  ID...        id of the resource to retrieve
+  [ID...]      id of the resource to retrieve
 
 FLAGS
   -H, --headers             show response headers
@@ -360,7 +360,7 @@ USAGE
 
 ARGUMENTS
   RESOURCE  the resource type
-  ID        id of the resource to retrieve
+  [ID]      id of the resource to retrieve
 
 FLAGS
   -H, --headers             show response headers
@@ -411,7 +411,7 @@ USAGE
 
 ARGUMENTS
   RESOURCE  the resource type
-  ID        id of the resource to update
+  [ID]      id of the resource to update
 
 FLAGS
   -D, --data=<value>                 the data file to use as request body

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"repository": "commercelayer/commercelayer-cli-plugin-provisioning",
 	"bugs": "https://github.com/commercelayer/commercelayer-cli-plugin-provisioning/issues",
 	"engines": {
-		"node": ">=20"
+		"node": ">=22"
 	},
 	"files": [
 		"/bin/run.*",
@@ -55,13 +55,14 @@
 		"release": "pnpm upgrade && pnpm prepack && pnpm postpack && pnpm test"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.8",
-		"@commercelayer/cli-dev": "^3.0.13",
+		"@biomejs/biome": "^2.4.9",
+		"@commercelayer/cli-dev": "oclif4",
 		"@oclif/plugin-help": "^6.2.40",
-		"@oclif/test": "^3.2.15",
+		"@oclif/test": "^4.1.17",
 		"@semantic-release/changelog": "^6.0.3",
 		"@semantic-release/git": "^10.0.1",
 		"@types/chai": "^5.2.3",
+		"@types/cli-progress": "^3.11.6",
 		"@types/inquirer": "^8.2.12",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^25.5.0",
@@ -74,9 +75,10 @@
 		"typescript": "^6.0.2"
 	},
 	"dependencies": {
-		"@commercelayer/cli-core": "^5.10.8",
+		"@commercelayer/cli-core": "oclif4",
+		"@commercelayer/cli-ux": "oclif4",
 		"@commercelayer/provisioning-sdk": "^2.10.1",
-		"@oclif/core": "^3.27.0",
+		"@oclif/core": "^4.10.3",
 		"inquirer": "^8.2.7",
 		"json-2-csv": "^5.5.10",
 		"tslib": "^2.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,17 @@ importers:
   .:
     dependencies:
       '@commercelayer/cli-core':
-        specifier: ^5.10.8
-        version: 5.10.8
+        specifier: oclif4
+        version: 6.0.0-oclif4.9
+      '@commercelayer/cli-ux':
+        specifier: oclif4
+        version: 2.0.0-oclif4.10(@oclif/core@4.10.3)
       '@commercelayer/provisioning-sdk':
         specifier: ^2.10.1
         version: 2.10.1
       '@oclif/core':
-        specifier: ^3.27.0
-        version: 3.27.0
+        specifier: ^4.10.3
+        version: 4.10.3
       inquirer:
         specifier: ^8.2.7
         version: 8.2.7(@types/node@25.5.0)
@@ -28,17 +31,17 @@ importers:
         version: 2.8.1
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.4.8
-        version: 2.4.8
+        specifier: ^2.4.9
+        version: 2.4.9
       '@commercelayer/cli-dev':
-        specifier: ^3.0.13
-        version: 3.0.13
+        specifier: oclif4
+        version: 4.0.0-oclif4.5
       '@oclif/plugin-help':
         specifier: ^6.2.40
         version: 6.2.40
       '@oclif/test':
-        specifier: ^3.2.15
-        version: 3.2.15
+        specifier: ^4.1.17
+        version: 4.1.17(@oclif/core@4.10.3)
       '@semantic-release/changelog':
         specifier: ^6.0.3
         version: 6.0.3(semantic-release@25.0.3(typescript@6.0.2))
@@ -48,6 +51,9 @@ importers:
       '@types/chai':
         specifier: ^5.2.3
         version: 5.2.3
+      '@types/cli-progress':
+        specifier: ^3.11.6
+        version: 3.11.6
       '@types/inquirer':
         specifier: ^8.2.12
         version: 8.2.12
@@ -124,44 +130,44 @@ packages:
     resolution: {integrity: sha512-0XLrOT4Cm3NEhhiME7l/8LbTXS4KdsbR4dSrY207KNKTcHLLTZ9EXt4ZpgnTfLvWQF3pGP2us4Zi1fYLo0N+Ow==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.973.24':
-    resolution: {integrity: sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==}
+  '@aws-sdk/core@3.973.25':
+    resolution: {integrity: sha512-TNrx7eq6nKNOO62HWPqoBqPLXEkW6nLZQGwjL6lq1jZtigWYbK1NbCnT7mKDzbLMHZfuOECUt3n6CzxjUW9HWQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/crc64-nvme@3.972.5':
     resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.22':
-    resolution: {integrity: sha512-cXp0VTDWT76p3hyK5D51yIKEfpf6/zsUvMfaB8CkyqadJxMQ8SbEeVroregmDlZbtG31wkj9ei0WnftmieggLg==}
+  '@aws-sdk/credential-provider-env@3.972.23':
+    resolution: {integrity: sha512-EamaclJcCEaPHp6wiVknNMM2RlsPMjAHSsYSFLNENBM8Wz92QPc6cOn3dif6vPDQt0Oo4IEghDy3NMDCzY/IvA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.24':
-    resolution: {integrity: sha512-h694K7+tRuepSRJr09wTvQfaEnjzsKZ5s7fbESrVds02GT/QzViJ94/HCNwM7bUfFxqpPXHxulZfL6Cou0dwPg==}
+  '@aws-sdk/credential-provider-http@3.972.25':
+    resolution: {integrity: sha512-qPymamdPcLp6ugoVocG1y5r69ScNiRzb0hogX25/ij+Wz7c7WnsgjLTaz7+eB5BfRxeyUwuw5hgULMuwOGOpcw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.24':
-    resolution: {integrity: sha512-O46fFmv0RDFWiWEA9/e6oW92BnsyAXuEgTTasxHligjn2RCr9L/DK773m/NoFaL3ZdNAUz8WxgxunleMnHAkeQ==}
+  '@aws-sdk/credential-provider-ini@3.972.25':
+    resolution: {integrity: sha512-G/v/PicYn4qs7xCv4vT6I4QKdvMyRvsgIFNBkUueCGlbLo7/PuKcNKgUozmLSsaYnE7jIl6UrfkP07EUubr48w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.24':
-    resolution: {integrity: sha512-sIk8oa6AzDoUhxsR11svZESqvzGuXesw62Rl2oW6wguZx8i9cdGCvkFg+h5K7iucUZP8wyWibUbJMc+J66cu5g==}
+  '@aws-sdk/credential-provider-login@3.972.25':
+    resolution: {integrity: sha512-bUdmyJeVua7SmD+g2a65x2/0YqsGn4K2k4GawI43js0odaNaIzpIhLtHehUnPnfLuyhPWbJR1NyuIO4iMVfM0w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.25':
-    resolution: {integrity: sha512-m7dR0Dsva2P+VUpL+VkC0WwiDby5pgmWXkRVDB5rlwv0jXJrQJf7YMtCoM8Wjk0H9jPeCYOxOXXcIgp/qp5Alg==}
+  '@aws-sdk/credential-provider-node@3.972.26':
+    resolution: {integrity: sha512-5XSK74rCXxCNj+UWv5bjq1EccYkiyW4XOHFU9NXnsCcQF8dJuHdua1qFg0m/LIwVOWklbKsrcnMtfxIXwgvwzQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.22':
-    resolution: {integrity: sha512-Os32s8/4gTZjBk5BtoS/cuTILaj+K72d0dVG7TCJX/fC4598cxwLDmf1AEHEpER5oL3K//yETjvFaz0V8oO5Xw==}
+  '@aws-sdk/credential-provider-process@3.972.23':
+    resolution: {integrity: sha512-IL/TFW59++b7MpHserjUblGrdP5UXy5Ekqqx1XQkERXBFJcZr74I7VaSrQT5dxdRMU16xGK4L0RQ5fQG1pMgnA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.24':
-    resolution: {integrity: sha512-PaFv7snEfypU2yXkpvfyWgddEbDLtgVe51wdZlinhc2doubBjUzJZZpgwuF2Jenl1FBydMhNpMjD6SBUM3qdSA==}
+  '@aws-sdk/credential-provider-sso@3.972.25':
+    resolution: {integrity: sha512-r4OGAfHmlEa1QBInHWz+/dOD4tRljcjVNQe9wJ/AJNXEj1d2WdsRLppvRFImRV6FIs+bTpjtL0a23V5ELQpRPw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.24':
-    resolution: {integrity: sha512-J6H4R1nvr3uBTqD/EeIPAskrBtET4WFfNhpFySr2xW7bVZOXpQfPjrLSIx65jcNjBmLXzWq8QFLdVoGxiGG/SA==}
+  '@aws-sdk/credential-provider-web-identity@3.972.25':
+    resolution: {integrity: sha512-uM1OtoJgj+yK3MlAmda8uR9WJJCdm5HB25JyCeFL5a5q1Fbafalf4uKidFO3/L0Pgd+Fsflkb4cM6jHIswi3QQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.8':
@@ -172,8 +178,8 @@ packages:
     resolution: {integrity: sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-flexible-checksums@3.974.4':
-    resolution: {integrity: sha512-fhCbZXPAyy8btnNbnBlR7Cc1nD54cETSvGn2wey71ehsM89AKPO8Dpco9DBAAgvrUdLrdHQepBXcyX4vxC5OwA==}
+  '@aws-sdk/middleware-flexible-checksums@3.974.5':
+    resolution: {integrity: sha512-SPSvF0G1t8m8CcB0L+ClNFszzQOvXaxmRj25oRWDf6aU+TuN2PXPFAJ9A6lt1IvX4oGAqqbTdMPTYs/SSHUYYQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-host-header@3.972.8':
@@ -188,36 +194,36 @@ packages:
     resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-recursion-detection@3.972.8':
-    resolution: {integrity: sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==}
+  '@aws-sdk/middleware-recursion-detection@3.972.9':
+    resolution: {integrity: sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.972.24':
-    resolution: {integrity: sha512-4sXxVC/enYgMkZefNMOzU6C6KtAXEvwVJLgNcUx1dvROH6GvKB5Sm2RGnGzTp0/PwkibIyMw4kOzF8tbLfaBAQ==}
+  '@aws-sdk/middleware-sdk-s3@3.972.26':
+    resolution: {integrity: sha512-5q7UGSTtt7/KF0Os8wj2VZtlLxeWJVb0e2eDrDJlWot2EIxUNKDDMPFq/FowUqrwZ40rO2bu6BypxaKNvQhI+g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-ssec@3.972.8':
     resolution: {integrity: sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.25':
-    resolution: {integrity: sha512-QxiMPofvOt8SwSynTOmuZfvvPM1S9QfkESBxB22NMHTRXCJhR5BygLl8IXfC4jELiisQgwsgUby21GtXfX3f/g==}
+  '@aws-sdk/middleware-user-agent@3.972.26':
+    resolution: {integrity: sha512-AilFIh4rI/2hKyyGN6XrB0yN96W2o7e7wyrPWCM6QjZM1mcC/pVkW3IWWRvuBWMpVP8Fg+rMpbzeLQ6dTM4gig==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.14':
-    resolution: {integrity: sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==}
+  '@aws-sdk/nested-clients@3.996.15':
+    resolution: {integrity: sha512-k6WAVNkub5DrU46iPQvH1m0xc1n+0dX79+i287tYJzf5g1yU2rX3uf4xNeL5JvK1NtYgfwMnsxHqhOXFBn367A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.9':
-    resolution: {integrity: sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng==}
+  '@aws-sdk/region-config-resolver@3.972.10':
+    resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/signature-v4-multi-region@3.996.12':
-    resolution: {integrity: sha512-abRObSqjVeKUUHIZfAp78PTYrEsxCgVKDs/YET357pzT5C02eDDEvmWyeEC2wglWcYC4UTbBFk22gd2YJUlCQg==}
+  '@aws-sdk/signature-v4-multi-region@3.996.14':
+    resolution: {integrity: sha512-4nZSrBr1NO+48HCM/6BRU8mnRjuHZjcpziCvLXZk5QVftwWz5Mxqbhwdz4xf7WW88buaTB8uRO2MHklSX1m0vg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1015.0':
-    resolution: {integrity: sha512-3OSD4y110nisRhHzFOjoEeHU4GQL4KpzkX9PxzWaiZe0Yg2+thZKM0Pn9DjYwezH5JYfh/K++xK/SE0IHGrmCQ==}
+  '@aws-sdk/token-providers@3.1018.0':
+    resolution: {integrity: sha512-97OPNJHy37wmGOX44xAcu6E9oSTiqK9uPcy/fWpmN5uB3JuEp1f6x60Xot/jp+FxwhQWIFUsVJFnm3QKqt7T6Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.6':
@@ -239,8 +245,8 @@ packages:
   '@aws-sdk/util-user-agent-browser@3.972.8':
     resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
 
-  '@aws-sdk/util-user-agent-node@3.973.11':
-    resolution: {integrity: sha512-1qdXbXo2s5MMLpUvw00284LsbhtlQ4ul7Zzdn5n+7p4WVgCMLqhxImpHIrjSoc72E/fyc4Wq8dLtUld2Gsh+lA==}
+  '@aws-sdk/util-user-agent-node@3.973.12':
+    resolution: {integrity: sha512-8phW0TS8ntENJgDcFewYT/Q8dOmarpvSxEjATu2GUBAutiHr++oEGCiBUwxslCMNvwW2cAPZNT53S/ym8zm/gg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -248,8 +254,8 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/xml-builder@3.972.15':
-    resolution: {integrity: sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==}
+  '@aws-sdk/xml-builder@3.972.16':
+    resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -323,59 +329,59 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.4.8':
-    resolution: {integrity: sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==}
+  '@biomejs/biome@2.4.9':
+    resolution: {integrity: sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.8':
-    resolution: {integrity: sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ==}
+  '@biomejs/cli-darwin-arm64@2.4.9':
+    resolution: {integrity: sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.8':
-    resolution: {integrity: sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==}
+  '@biomejs/cli-darwin-x64@2.4.9':
+    resolution: {integrity: sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.8':
-    resolution: {integrity: sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==}
+  '@biomejs/cli-linux-arm64-musl@2.4.9':
+    resolution: {integrity: sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.8':
-    resolution: {integrity: sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==}
+  '@biomejs/cli-linux-arm64@2.4.9':
+    resolution: {integrity: sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.8':
-    resolution: {integrity: sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==}
+  '@biomejs/cli-linux-x64-musl@2.4.9':
+    resolution: {integrity: sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.8':
-    resolution: {integrity: sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==}
+  '@biomejs/cli-linux-x64@2.4.9':
+    resolution: {integrity: sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.8':
-    resolution: {integrity: sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==}
+  '@biomejs/cli-win32-arm64@2.4.9':
+    resolution: {integrity: sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.8':
-    resolution: {integrity: sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==}
+  '@biomejs/cli-win32-x64@2.4.9':
+    resolution: {integrity: sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -384,18 +390,24 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@commercelayer/cli-core@5.10.8':
-    resolution: {integrity: sha512-n6ZmGSkiiJDoftQMDim3uY+R2+lb47aNw6rvG48PAnEPY5+Er5Red7qO7+/+YSTgPUXTe2LcNJnrj2zkSJKhzQ==}
-    engines: {node: '>=20'}
+  '@commercelayer/cli-core@6.0.0-oclif4.9':
+    resolution: {integrity: sha512-E9lAuVDhQ0uDxncq1MGR8mB0C21WeixQSS+Qlkv2X65nYn87f6UCyGL3z7nUxezfRS1sIfaH7Mt/57lr2mrROA==}
+    engines: {node: '>=22'}
 
-  '@commercelayer/cli-dev@3.0.13':
-    resolution: {integrity: sha512-+RA7QQ1SJhK/eZsz2mn9Mgwgf2DiKDNpqNYxoOtCYWvunlQo2e2WoQvFrAdlCRwtHYJqMNJcLsBAZRtWVe7WFw==}
-    engines: {node: '>=20'}
+  '@commercelayer/cli-dev@4.0.0-oclif4.5':
+    resolution: {integrity: sha512-qUuYdWI9jBhQlQ6v+/v9f8mc1B2rw3XqoBkS56FZukKSGHM9laWqMTStjKCrKy0hVUdBR9Af0XGDCRj4Peki2g==}
+    engines: {node: '>=22'}
     hasBin: true
 
-  '@commercelayer/js-auth@6.7.2':
-    resolution: {integrity: sha512-kk4VqN2iEOreXFq76YqTP83KhBs09Z5Ez9nZNlikXWf5DXzkrOfShqqEwq8ezHjSOlqs4xVyxgQzsEdPP35CeQ==}
-    engines: {node: '>=18.0.0'}
+  '@commercelayer/cli-ux@2.0.0-oclif4.10':
+    resolution: {integrity: sha512-uOtoy2kBXukMJBZhNm75vhrGLTsdqb0gQcbQ88+o0M+clRExMEkrgA2uNPxX3G7NQqSkTk432z/Ok2I8FfRftg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@oclif/core': ^4
+
+  '@commercelayer/js-auth@7.3.0':
+    resolution: {integrity: sha512-o4HkMHqXqhPJ3gOA/61Na9T0ssLluV/SQEPtnb/N9/WpbiemEW43M1h/Iuc0/H8fSThqWe3Crt5HwGT5qAz6vQ==}
+    engines: {node: '>=20.0.0'}
 
   '@commercelayer/provisioning-sdk@2.10.1':
     resolution: {integrity: sha512-nz9ogulJmPn6lmPhtqMRdpL79pKFNQHeLi43a/gH5GsX21RbtCm6diIRpzTp7GP7RGYHixi7H2KhgOOoAkQlag==}
@@ -743,24 +755,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
-
-  '@oclif/core@3.27.0':
-    resolution: {integrity: sha512-Fg93aNFvXzBq5L7ztVHFP2nYwWU1oTCq48G0TjF/qC1UN36KWa2H5Hsm72kERd5x/sjy2M2Tn4kDEorUlpXOlw==}
-    engines: {node: '>=18.0.0'}
-
-  '@oclif/core@4.10.2':
-    resolution: {integrity: sha512-3GvDh5nqpIE8566qUF5cBHKog9DFV9XgBeuR0nUrz0OMuz2FPYHat1AZHOwyQbvH9OKL4gJNQZHcsDOqDM/FRA==}
+  '@oclif/core@4.10.3':
+    resolution: {integrity: sha512-0mD8vcrrX5uRsxzvI8tbWmSVGngvZA/Qo6O0ZGvLPAWEauSf5GFniwgirhY0SkszuHwu0S1J1ivj/jHmqtIDuA==}
     engines: {node: '>=18.0.0'}
 
   '@oclif/core@4.9.0':
@@ -779,9 +775,11 @@ packages:
     resolution: {integrity: sha512-y8BiMMiX3gnDO3kSck7R61bB74N8SI38pN9LbpaDlhZcjcN27wuIR5trePFxTxx85iow1YC5qvzYtwUZsDVjXg==}
     engines: {node: '>=18.0.0'}
 
-  '@oclif/test@3.2.15':
-    resolution: {integrity: sha512-XqG3RosozNqySkxSXInU12Xec2sPSOkqYHJDfdFZiWG3a8Cxu4dnPiAQvms+BJsOlLQmfEQlSHqiyVUKOMHhXA==}
+  '@oclif/test@4.1.17':
+    resolution: {integrity: sha512-OaD6/2vW9MqL58ZtaTGO1wc2vnPxZ/LLN0qp/+HVdMsBt/UDubxZreC3cxGR9rT8SMfyBvGIU8MzmZEBuiikAQ==}
     engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@oclif/core': '>= 3.0.0'
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -909,24 +907,6 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
-
-  '@sinonjs/commons@3.0.1':
-    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
-
-  '@sinonjs/fake-timers@10.3.0':
-    resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
-
-  '@sinonjs/fake-timers@11.3.1':
-    resolution: {integrity: sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==}
-
-  '@sinonjs/samsam@8.0.3':
-    resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
-
-  '@sinonjs/text-encoding@0.7.3':
-    resolution: {integrity: sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==}
-    deprecated: |-
-      Deprecated: no longer maintained and no longer used by Sinon packages. See
-        https://github.com/sinonjs/nise/issues/243 for replacement details.
 
   '@smithy/abort-controller@4.2.12':
     resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
@@ -1163,9 +1143,6 @@ packages:
   '@types/inquirer@8.2.12':
     resolution: {integrity: sha512-YxURZF2ZsSjU5TAe06tW0M3sL4UI9AMPA6dd8I72uOtppzNafcY38xkYgCZ/vsVOAyNdzHmvtTpLWilOrbP0dQ==}
 
-  '@types/lodash@4.17.24':
-    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
-
   '@types/mocha@10.0.10':
     resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
 
@@ -1180,12 +1157,6 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
-
-  '@types/sinon@21.0.0':
-    resolution: {integrity: sha512-+oHKZ0lTI+WVLxx1IbJDNmReQaIsQJjN2e7UUrJHEeByG7bFeKJYsv1E75JxTQ9QKJDp21bAa/0W2Xo4srsDnw==}
-
-  '@types/sinonjs__fake-timers@15.0.1':
-    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
 
   '@types/through@0.0.33':
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
@@ -1265,13 +1236,6 @@ packages:
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
-  array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
-
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1296,8 +1260,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.10:
-    resolution: {integrity: sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==}
+  baseline-browser-mapping@2.10.11:
+    resolution: {integrity: sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1320,8 +1284,8 @@ packages:
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1379,10 +1343,6 @@ packages:
     resolution: {integrity: sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==}
     hasBin: true
 
-  chai@4.5.0:
-    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
-    engines: {node: '>=4'}
-
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1408,9 +1368,6 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
-
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -1599,10 +1556,6 @@ packages:
     resolution: {integrity: sha512-e7oWH1LzIdv/prMQ7pmlDlaVoL64glqzvNgkgQNgyec9ORPHrT2jaOqMtRyqJuwWjtfb6v+2rk9pmaHj+F137A==}
     engines: {node: '>= 16'}
 
-  deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
-    engines: {node: '>=6'}
-
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -1625,10 +1578,6 @@ packages:
   detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  diff@5.2.2:
-    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
-    engines: {node: '>=0.3.1'}
 
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
@@ -1663,8 +1612,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.322:
-    resolution: {integrity: sha512-vFU34OcrvMcH66T+dYC3G4nURmgfDVewMIu6Q2urXpumAPSMmzvcn04KVVV8Opikq8Vs5nUbO/8laNhNRqSzYw==}
+  electron-to-chromium@1.5.325:
+    resolution: {integrity: sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1738,17 +1687,8 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
-  fancy-test@3.0.16:
-    resolution: {integrity: sha512-y1xZFpyYbE2TMiT+agOW2Emv8gr73zvDrKKbcXc8L+gMyIVJFn71cc4ICfzu2zEXjHirpHpdDJN0JBX99wwDXQ==}
-    engines: {node: '>=18.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
-
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
 
   fast-levenshtein@3.0.0:
     resolution: {integrity: sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==}
@@ -1763,9 +1703,6 @@ packages:
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
-
-  fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1880,9 +1817,6 @@ packages:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
-  get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
@@ -1922,10 +1856,6 @@ packages:
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -1937,10 +1867,6 @@ packages:
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
-    engines: {node: '>=10'}
-
-  globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
   got@13.0.0:
@@ -2049,10 +1975,6 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2121,17 +2043,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-
-  is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
 
   is-installed-globally@0.4.0:
     resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==}
@@ -2285,9 +2199,6 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  json-stringify-safe@5.0.1:
-    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-
   json-with-bigint@3.5.8:
     resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
 
@@ -2305,9 +2216,6 @@ packages:
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
-
-  just-extend@6.2.0:
-    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -2384,9 +2292,6 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
-
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
@@ -2438,10 +2343,6 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
-  merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -2491,9 +2392,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
-  mock-stdin@1.0.0:
-    resolution: {integrity: sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2520,15 +2418,8 @@ packages:
   nerf-dart@1.0.0:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
 
-  nise@5.1.9:
-    resolution: {integrity: sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==}
-
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
-
-  nock@13.5.6:
-    resolution: {integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==}
-    engines: {node: '>= 10.13'}
 
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
@@ -2582,8 +2473,8 @@ packages:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
 
-  npm@11.12.0:
-    resolution: {integrity: sha512-xPhOap4ZbJWyd7DAOukP564WFwNSGu/2FeTRFHhiiKthcauxhH/NpkJAQm24xD+cAn8av5tQ00phi98DqtfLsg==}
+  npm@11.12.1:
+    resolution: {integrity: sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
     bundledDependencies:
@@ -2831,15 +2722,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@6.3.0:
-    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
-
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2875,19 +2760,12 @@ packages:
     resolution: {integrity: sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==}
     engines: {node: '>=8'}
 
-  propagate@2.0.1:
-    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
-    engines: {node: '>= 8'}
-
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
   pupa@2.1.1:
     resolution: {integrity: sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==}
     engines: {node: '>=8'}
-
-  queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
@@ -2975,10 +2853,6 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
-  reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
@@ -2987,9 +2861,6 @@ packages:
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
-
-  run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -3056,15 +2927,8 @@ packages:
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
-  sinon@16.1.3:
-    resolution: {integrity: sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==}
-
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
-    engines: {node: '>=8'}
-
-  slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
   slice-ansi@4.0.0:
@@ -3109,10 +2973,6 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
-  stdout-stderr@0.1.13:
-    resolution: {integrity: sha512-Xnt9/HHHYfjZ7NeQLvuQDyL1LnbsbddgMFKCuaQKwGCdJm8LnstZIXop+uOY36UR1UXXoHXfMbC1KlVdVd2JLA==}
-    engines: {node: '>=8.0.0'}
 
   stream-combiner2@1.1.1:
     resolution: {integrity: sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==}
@@ -3264,14 +3124,6 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
-  type-detect@4.0.8:
-    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
-    engines: {node: '>=4'}
-
-  type-detect@4.1.0:
-    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
-    engines: {node: '>=4'}
-
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
@@ -3323,8 +3175,8 @@ packages:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
 
-  undici@7.24.5:
-    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
+  undici@7.24.6:
+    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -3583,17 +3435,17 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/credential-provider-node': 3.972.25
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/credential-provider-node': 3.972.26
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.25
-      '@aws-sdk/region-config-resolver': 3.972.9
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.26
+      '@aws-sdk/region-config-resolver': 3.972.10
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.11
+      '@aws-sdk/util-user-agent-node': 3.973.12
       '@smithy/config-resolver': 4.4.13
       '@smithy/core': 3.23.12
       '@smithy/fetch-http-handler': 5.3.15
@@ -3630,24 +3482,24 @@ snapshots:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/credential-provider-node': 3.972.25
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/credential-provider-node': 3.972.26
       '@aws-sdk/middleware-bucket-endpoint': 3.972.8
       '@aws-sdk/middleware-expect-continue': 3.972.8
-      '@aws-sdk/middleware-flexible-checksums': 3.974.4
+      '@aws-sdk/middleware-flexible-checksums': 3.974.5
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-location-constraint': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-sdk-s3': 3.972.24
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-sdk-s3': 3.972.26
       '@aws-sdk/middleware-ssec': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.25
-      '@aws-sdk/region-config-resolver': 3.972.9
-      '@aws-sdk/signature-v4-multi-region': 3.996.12
+      '@aws-sdk/middleware-user-agent': 3.972.26
+      '@aws-sdk/region-config-resolver': 3.972.10
+      '@aws-sdk/signature-v4-multi-region': 3.996.14
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.11
+      '@aws-sdk/util-user-agent-node': 3.973.12
       '@smithy/config-resolver': 4.4.13
       '@smithy/core': 3.23.12
       '@smithy/eventstream-serde-browser': 4.2.12
@@ -3685,10 +3537,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.973.24':
+  '@aws-sdk/core@3.973.25':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@aws-sdk/xml-builder': 3.972.15
+      '@aws-sdk/xml-builder': 3.972.16
       '@smithy/core': 3.23.12
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
@@ -3706,17 +3558,17 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.22':
+  '@aws-sdk/credential-provider-env@3.972.23':
     dependencies:
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.24':
+  '@aws-sdk/credential-provider-http@3.972.25':
     dependencies:
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/types': 3.973.6
       '@smithy/fetch-http-handler': 5.3.15
       '@smithy/node-http-handler': 4.5.0
@@ -3727,16 +3579,16 @@ snapshots:
       '@smithy/util-stream': 4.5.20
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.24':
+  '@aws-sdk/credential-provider-ini@3.972.25':
     dependencies:
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/credential-provider-env': 3.972.22
-      '@aws-sdk/credential-provider-http': 3.972.24
-      '@aws-sdk/credential-provider-login': 3.972.24
-      '@aws-sdk/credential-provider-process': 3.972.22
-      '@aws-sdk/credential-provider-sso': 3.972.24
-      '@aws-sdk/credential-provider-web-identity': 3.972.24
-      '@aws-sdk/nested-clients': 3.996.14
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/credential-provider-env': 3.972.23
+      '@aws-sdk/credential-provider-http': 3.972.25
+      '@aws-sdk/credential-provider-login': 3.972.25
+      '@aws-sdk/credential-provider-process': 3.972.23
+      '@aws-sdk/credential-provider-sso': 3.972.25
+      '@aws-sdk/credential-provider-web-identity': 3.972.25
+      '@aws-sdk/nested-clients': 3.996.15
       '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
@@ -3746,10 +3598,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.24':
+  '@aws-sdk/credential-provider-login@3.972.25':
     dependencies:
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/nested-clients': 3.996.14
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.15
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/protocol-http': 5.3.12
@@ -3759,14 +3611,14 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.25':
+  '@aws-sdk/credential-provider-node@3.972.26':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.22
-      '@aws-sdk/credential-provider-http': 3.972.24
-      '@aws-sdk/credential-provider-ini': 3.972.24
-      '@aws-sdk/credential-provider-process': 3.972.22
-      '@aws-sdk/credential-provider-sso': 3.972.24
-      '@aws-sdk/credential-provider-web-identity': 3.972.24
+      '@aws-sdk/credential-provider-env': 3.972.23
+      '@aws-sdk/credential-provider-http': 3.972.25
+      '@aws-sdk/credential-provider-ini': 3.972.25
+      '@aws-sdk/credential-provider-process': 3.972.23
+      '@aws-sdk/credential-provider-sso': 3.972.25
+      '@aws-sdk/credential-provider-web-identity': 3.972.25
       '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
@@ -3776,20 +3628,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.22':
+  '@aws-sdk/credential-provider-process@3.972.23':
     dependencies:
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.24':
+  '@aws-sdk/credential-provider-sso@3.972.25':
     dependencies:
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/nested-clients': 3.996.14
-      '@aws-sdk/token-providers': 3.1015.0
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.15
+      '@aws-sdk/token-providers': 3.1018.0
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -3798,10 +3650,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.24':
+  '@aws-sdk/credential-provider-web-identity@3.972.25':
     dependencies:
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/nested-clients': 3.996.14
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.15
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -3827,12 +3679,12 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-flexible-checksums@3.974.4':
+  '@aws-sdk/middleware-flexible-checksums@3.974.5':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/crc64-nvme': 3.972.5
       '@aws-sdk/types': 3.973.6
       '@smithy/is-array-buffer': 4.2.2
@@ -3863,7 +3715,7 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-recursion-detection@3.972.8':
+  '@aws-sdk/middleware-recursion-detection@3.972.9':
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@aws/lambda-invoke-store': 0.2.4
@@ -3871,9 +3723,9 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.24':
+  '@aws-sdk/middleware-sdk-s3@3.972.26':
     dependencies:
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/core': 3.23.12
@@ -3894,9 +3746,9 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.25':
+  '@aws-sdk/middleware-user-agent@3.972.26':
     dependencies:
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@smithy/core': 3.23.12
@@ -3905,20 +3757,20 @@ snapshots:
       '@smithy/util-retry': 4.2.12
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.996.14':
+  '@aws-sdk/nested-clients@3.996.15':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/core': 3.973.25
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.25
-      '@aws-sdk/region-config-resolver': 3.972.9
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.26
+      '@aws-sdk/region-config-resolver': 3.972.10
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.11
+      '@aws-sdk/util-user-agent-node': 3.973.12
       '@smithy/config-resolver': 4.4.13
       '@smithy/core': 3.23.12
       '@smithy/fetch-http-handler': 5.3.15
@@ -3948,7 +3800,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/region-config-resolver@3.972.9':
+  '@aws-sdk/region-config-resolver@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@smithy/config-resolver': 4.4.13
@@ -3956,19 +3808,19 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.12':
+  '@aws-sdk/signature-v4-multi-region@3.996.14':
     dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.24
+      '@aws-sdk/middleware-sdk-s3': 3.972.26
       '@aws-sdk/types': 3.973.6
       '@smithy/protocol-http': 5.3.12
       '@smithy/signature-v4': 5.3.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.1015.0':
+  '@aws-sdk/token-providers@3.1018.0':
     dependencies:
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/nested-clients': 3.996.14
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.15
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -4005,16 +3857,16 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.973.11':
+  '@aws-sdk/util-user-agent-node@3.973.12':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.25
+      '@aws-sdk/middleware-user-agent': 3.972.26
       '@aws-sdk/types': 3.973.6
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.15':
+  '@aws-sdk/xml-builder@3.972.16':
     dependencies:
       '@smithy/types': 4.13.1
       fast-xml-parser: 5.5.8
@@ -4122,64 +3974,85 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@biomejs/biome@2.4.8':
+  '@biomejs/biome@2.4.9':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.8
-      '@biomejs/cli-darwin-x64': 2.4.8
-      '@biomejs/cli-linux-arm64': 2.4.8
-      '@biomejs/cli-linux-arm64-musl': 2.4.8
-      '@biomejs/cli-linux-x64': 2.4.8
-      '@biomejs/cli-linux-x64-musl': 2.4.8
-      '@biomejs/cli-win32-arm64': 2.4.8
-      '@biomejs/cli-win32-x64': 2.4.8
+      '@biomejs/cli-darwin-arm64': 2.4.9
+      '@biomejs/cli-darwin-x64': 2.4.9
+      '@biomejs/cli-linux-arm64': 2.4.9
+      '@biomejs/cli-linux-arm64-musl': 2.4.9
+      '@biomejs/cli-linux-x64': 2.4.9
+      '@biomejs/cli-linux-x64-musl': 2.4.9
+      '@biomejs/cli-win32-arm64': 2.4.9
+      '@biomejs/cli-win32-x64': 2.4.9
 
-  '@biomejs/cli-darwin-arm64@2.4.8':
+  '@biomejs/cli-darwin-arm64@2.4.9':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.8':
+  '@biomejs/cli-darwin-x64@2.4.9':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.8':
+  '@biomejs/cli-linux-arm64-musl@2.4.9':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.8':
+  '@biomejs/cli-linux-arm64@2.4.9':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.8':
+  '@biomejs/cli-linux-x64-musl@2.4.9':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.8':
+  '@biomejs/cli-linux-x64@2.4.9':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.8':
+  '@biomejs/cli-win32-arm64@2.4.9':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.8':
+  '@biomejs/cli-win32-x64@2.4.9':
     optional: true
 
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commercelayer/cli-core@5.10.8':
+  '@commercelayer/cli-core@6.0.0-oclif4.9':
     dependencies:
-      '@commercelayer/js-auth': 6.7.2
-      '@oclif/core': 3.27.0
+      '@commercelayer/js-auth': 7.3.0
+      '@oclif/core': 4.10.3
       chalk: 4.1.2
       jsonwebtoken: 9.0.3
       update-notifier-cjs: 5.1.7
     transitivePeerDependencies:
       - encoding
 
-  '@commercelayer/cli-dev@3.0.13':
+  '@commercelayer/cli-dev@4.0.0-oclif4.5':
     dependencies:
-      '@oclif/core': 3.27.0
+      '@oclif/core': 4.10.3
       fs-extra: 10.1.0
       github-slugger: 1.5.0
       lodash: 4.17.23
       normalize-package-data: 5.0.0
       tslib: 2.8.1
 
-  '@commercelayer/js-auth@6.7.2': {}
+  '@commercelayer/cli-ux@2.0.0-oclif4.10(@oclif/core@4.10.3)':
+    dependencies:
+      '@oclif/core': 4.10.3
+      ansi-escapes: 4.3.2
+      ansi-styles: 4.3.0
+      cardinal: 2.1.1
+      chalk: 4.1.2
+      cli-progress: 3.12.0
+      color: 4.2.3
+      hyperlinker: 1.0.0
+      js-yaml: 3.14.2
+      natural-orderby: 2.0.3
+      object-treeify: 1.1.33
+      password-prompt: 1.1.3
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      supports-color: 8.1.1
+      supports-hyperlinks: 2.3.0
+      wordwrap: 1.0.0
+
+  '@commercelayer/js-auth@7.3.0': {}
 
   '@commercelayer/provisioning-sdk@2.10.1': {}
 
@@ -4465,50 +4338,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@nodelib/fs.scandir@2.1.5':
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@2.0.5': {}
-
-  '@nodelib/fs.walk@1.2.8':
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.20.1
-
-  '@oclif/core@3.27.0':
-    dependencies:
-      '@types/cli-progress': 3.11.6
-      ansi-escapes: 4.3.2
-      ansi-styles: 4.3.0
-      cardinal: 2.1.1
-      chalk: 4.1.2
-      clean-stack: 3.0.1
-      cli-progress: 3.12.0
-      color: 4.2.3
-      debug: 4.4.3(supports-color@8.1.1)
-      ejs: 3.1.10
-      get-package-type: 0.1.0
-      globby: 11.1.0
-      hyperlinker: 1.0.0
-      indent-string: 4.0.0
-      is-wsl: 2.2.0
-      js-yaml: 3.14.2
-      minimatch: 9.0.9
-      natural-orderby: 2.0.3
-      object-treeify: 1.1.33
-      password-prompt: 1.1.3
-      slice-ansi: 4.0.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      supports-color: 8.1.1
-      supports-hyperlinks: 2.3.0
-      widest-line: 3.1.0
-      wordwrap: 1.0.0
-      wrap-ansi: 7.0.0
-
-  '@oclif/core@4.10.2':
+  '@oclif/core@4.10.3':
     dependencies:
       ansi-escapes: 4.3.2
       ansis: 3.17.0
@@ -4552,12 +4382,12 @@ snapshots:
 
   '@oclif/plugin-help@6.2.40':
     dependencies:
-      '@oclif/core': 4.10.2
+      '@oclif/core': 4.10.3
 
   '@oclif/plugin-not-found@3.2.77(@types/node@25.5.0)':
     dependencies:
       '@inquirer/prompts': 7.10.1(@types/node@25.5.0)
-      '@oclif/core': 4.10.2
+      '@oclif/core': 4.10.3
       ansis: 3.17.0
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
@@ -4565,7 +4395,7 @@ snapshots:
 
   '@oclif/plugin-warn-if-update-available@3.1.57':
     dependencies:
-      '@oclif/core': 4.9.0
+      '@oclif/core': 4.10.3
       ansis: 3.17.0
       debug: 4.4.3(supports-color@8.1.1)
       http-call: 5.3.0
@@ -4574,11 +4404,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@oclif/test@3.2.15':
+  '@oclif/test@4.1.17(@oclif/core@4.10.3)':
     dependencies:
-      '@oclif/core': 3.27.0
-      chai: 4.5.0
-      fancy-test: 3.0.16
+      '@oclif/core': 4.10.3
+      ansis: 3.17.0
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4717,7 +4547,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.3(typescript@6.0.2)
       tinyglobby: 0.2.15
-      undici: 7.24.5
+      undici: 7.24.6
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -4733,7 +4563,7 @@ snapshots:
       lodash-es: 4.17.23
       nerf-dart: 1.0.0
       normalize-url: 9.0.0
-      npm: 11.12.0
+      npm: 11.12.1
       rc: 1.2.8
       read-pkg: 10.1.0
       registry-auth-token: 5.1.1
@@ -4764,25 +4594,6 @@ snapshots:
   '@sindresorhus/is@5.6.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
-
-  '@sinonjs/commons@3.0.1':
-    dependencies:
-      type-detect: 4.0.8
-
-  '@sinonjs/fake-timers@10.3.0':
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-
-  '@sinonjs/fake-timers@11.3.1':
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-
-  '@sinonjs/samsam@8.0.3':
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-      type-detect: 4.1.0
-
-  '@sinonjs/text-encoding@0.7.3': {}
 
   '@smithy/abort-controller@4.2.12':
     dependencies:
@@ -5145,8 +4956,6 @@ snapshots:
       '@types/through': 0.0.33
       rxjs: 7.8.2
 
-  '@types/lodash@4.17.24': {}
-
   '@types/mocha@10.0.10': {}
 
   '@types/mute-stream@0.0.4':
@@ -5162,12 +4971,6 @@ snapshots:
       undici-types: 7.18.2
 
   '@types/normalize-package-data@2.4.4': {}
-
-  '@types/sinon@21.0.0':
-    dependencies:
-      '@types/sinonjs__fake-timers': 15.0.1
-
-  '@types/sinonjs__fake-timers@15.0.1': {}
 
   '@types/through@0.0.33':
     dependencies:
@@ -5235,10 +5038,6 @@ snapshots:
 
   array-ify@1.0.0: {}
 
-  array-union@2.1.0: {}
-
-  assertion-error@1.1.0: {}
-
   assertion-error@2.0.1: {}
 
   astral-regex@2.0.0: {}
@@ -5255,7 +5054,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.10: {}
+  baseline-browser-mapping@2.10.11: {}
 
   before-after-hook@4.0.0: {}
 
@@ -5284,7 +5083,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5296,9 +5095,9 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.10
+      baseline-browser-mapping: 2.10.11
       caniuse-lite: 1.0.30001781
-      electron-to-chromium: 1.5.322
+      electron-to-chromium: 1.5.325
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
@@ -5352,16 +5151,6 @@ snapshots:
       ansicolors: 0.3.2
       redeyed: 2.1.1
 
-  chai@4.5.0:
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
-
   chai@6.2.2: {}
 
   chalk@2.4.2:
@@ -5395,10 +5184,6 @@ snapshots:
   char-regex@1.0.2: {}
 
   chardet@2.1.1: {}
-
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
 
   chokidar@4.0.3:
     dependencies:
@@ -5588,10 +5373,6 @@ snapshots:
 
   deeks@3.1.0: {}
 
-  deep-eql@4.1.4:
-    dependencies:
-      type-detect: 4.1.0
-
   deep-extend@0.6.0: {}
 
   default-require-extensions@3.0.1:
@@ -5607,8 +5388,6 @@ snapshots:
   detect-indent@7.0.2: {}
 
   detect-newline@4.0.1: {}
-
-  diff@5.2.2: {}
 
   diff@7.0.0: {}
 
@@ -5641,7 +5420,7 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.322: {}
+  electron-to-chromium@1.5.325: {}
 
   emoji-regex@10.6.0: {}
 
@@ -5746,29 +5525,7 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
-  fancy-test@3.0.16:
-    dependencies:
-      '@types/chai': 5.2.3
-      '@types/lodash': 4.17.24
-      '@types/node': 25.5.0
-      '@types/sinon': 21.0.0
-      lodash: 4.17.23
-      mock-stdin: 1.0.0
-      nock: 13.5.6
-      sinon: 16.1.3
-      stdout-stderr: 0.1.13
-    transitivePeerDependencies:
-      - supports-color
-
   fast-content-type-parse@3.0.0: {}
-
-  fast-glob@3.3.3:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
 
   fast-levenshtein@3.0.0:
     dependencies:
@@ -5785,10 +5542,6 @@ snapshots:
       strnum: 2.2.2
 
   fastest-levenshtein@1.0.16: {}
-
-  fastq@1.20.1:
-    dependencies:
-      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -5897,8 +5650,6 @@ snapshots:
 
   get-east-asian-width@1.5.0: {}
 
-  get-func-name@2.0.2: {}
-
   get-package-type@0.1.0: {}
 
   get-stdin@9.0.0: {}
@@ -5933,10 +5684,6 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
-
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -5955,15 +5702,6 @@ snapshots:
   global-dirs@3.0.1:
     dependencies:
       ini: 2.0.0
-
-  globby@11.1.0:
-    dependencies:
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.3.3
-      ignore: 5.3.2
-      merge2: 1.4.1
-      slash: 3.0.0
 
   got@13.0.0:
     dependencies:
@@ -6078,8 +5816,6 @@ snapshots:
 
   ieee754@1.2.1: {}
 
-  ignore@5.3.2: {}
-
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -6149,13 +5885,7 @@ snapshots:
 
   is-docker@2.2.1: {}
 
-  is-extglob@2.1.1: {}
-
   is-fullwidth-code-point@3.0.0: {}
-
-  is-glob@4.0.3:
-    dependencies:
-      is-extglob: 2.1.1
 
   is-installed-globally@0.4.0:
     dependencies:
@@ -6299,8 +6029,6 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
-  json-stringify-safe@5.0.1: {}
-
   json-with-bigint@3.5.8: {}
 
   json5@2.2.3: {}
@@ -6327,8 +6055,6 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.7.4
-
-  just-extend@6.2.0: {}
 
   jwa@2.0.1:
     dependencies:
@@ -6400,10 +6126,6 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
-
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -6451,8 +6173,6 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
-  merge2@1.4.1: {}
-
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -6470,7 +6190,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimatch@5.1.9:
     dependencies:
@@ -6508,8 +6228,6 @@ snapshots:
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
-  mock-stdin@1.0.0: {}
-
   ms@2.1.3: {}
 
   mute-stream@0.0.8: {}
@@ -6530,26 +6248,10 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  nise@5.1.9:
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 11.3.1
-      '@sinonjs/text-encoding': 0.7.3
-      just-extend: 6.2.0
-      path-to-regexp: 6.3.0
-
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.8.1
-
-  nock@13.5.6:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      json-stringify-safe: 5.0.1
-      propagate: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   node-emoji@2.2.0:
     dependencies:
@@ -6604,7 +6306,7 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  npm@11.12.0: {}
+  npm@11.12.1: {}
 
   nyc@18.0.0:
     dependencies:
@@ -6828,11 +6530,7 @@ snapshots:
       lru-cache: 11.2.7
       minipass: 7.1.3
 
-  path-to-regexp@6.3.0: {}
-
   path-type@4.0.0: {}
-
-  pathval@1.1.1: {}
 
   picocolors@1.1.1: {}
 
@@ -6861,15 +6559,11 @@ snapshots:
     dependencies:
       fromentries: 1.3.2
 
-  propagate@2.0.1: {}
-
   proto-list@1.2.4: {}
 
   pupa@2.1.1:
     dependencies:
       escape-goat: 2.1.1
-
-  queue-microtask@1.2.3: {}
 
   quick-lru@5.1.1: {}
 
@@ -6969,18 +6663,12 @@ snapshots:
 
   retry@0.13.1: {}
 
-  reusify@1.1.0: {}
-
   rimraf@6.1.3:
     dependencies:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
   run-async@2.4.1: {}
-
-  run-parallel@1.2.0:
-    dependencies:
-      queue-microtask: 1.2.3
 
   rxjs@7.8.2:
     dependencies:
@@ -7068,20 +6756,9 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.4
 
-  sinon@16.1.3:
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 10.3.0
-      '@sinonjs/samsam': 8.0.3
-      diff: 5.2.2
-      nise: 5.1.9
-      supports-color: 7.2.0
-
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
-
-  slash@3.0.0: {}
 
   slice-ansi@4.0.0:
     dependencies:
@@ -7140,13 +6817,6 @@ snapshots:
       through2: 2.0.5
 
   sprintf-js@1.0.3: {}
-
-  stdout-stderr@0.1.13:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   stream-combiner2@1.1.1:
     dependencies:
@@ -7297,10 +6967,6 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  type-detect@4.0.8: {}
-
-  type-detect@4.1.0: {}
-
   type-fest@0.20.2: {}
 
   type-fest@0.21.3: {}
@@ -7332,7 +6998,7 @@ snapshots:
 
   undici@6.24.1: {}
 
-  undici@7.24.5: {}
+  undici@7.24.6: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@commercelayer/cli-core':
         specifier: oclif4
-        version: 6.0.0-oclif4.9
+        version: 6.0.0-oclif4.11
       '@commercelayer/cli-ux':
         specifier: oclif4
-        version: 2.0.0-oclif4.10(@oclif/core@4.10.3)
+        version: 2.0.0-oclif4.11(@oclif/core@4.10.3)
       '@commercelayer/provisioning-sdk':
         specifier: ^2.10.1
         version: 2.10.1
@@ -35,7 +35,7 @@ importers:
         version: 2.4.9
       '@commercelayer/cli-dev':
         specifier: oclif4
-        version: 4.0.0-oclif4.5
+        version: 4.0.0-oclif4.6
       '@oclif/plugin-help':
         specifier: ^6.2.40
         version: 6.2.40
@@ -390,17 +390,17 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@commercelayer/cli-core@6.0.0-oclif4.9':
-    resolution: {integrity: sha512-E9lAuVDhQ0uDxncq1MGR8mB0C21WeixQSS+Qlkv2X65nYn87f6UCyGL3z7nUxezfRS1sIfaH7Mt/57lr2mrROA==}
+  '@commercelayer/cli-core@6.0.0-oclif4.11':
+    resolution: {integrity: sha512-HD4NjYdvkXoeASapO+kkcwYAVw3M29hkVyY1w0SHjozX40tWJwUGFhw97RMV8B6kNuqBZuj/SkS0tX7F/76VNg==}
     engines: {node: '>=22'}
 
-  '@commercelayer/cli-dev@4.0.0-oclif4.5':
-    resolution: {integrity: sha512-qUuYdWI9jBhQlQ6v+/v9f8mc1B2rw3XqoBkS56FZukKSGHM9laWqMTStjKCrKy0hVUdBR9Af0XGDCRj4Peki2g==}
+  '@commercelayer/cli-dev@4.0.0-oclif4.6':
+    resolution: {integrity: sha512-mXD0Zd5/GN+f7Cs91u4dgC8e/ncHKCLGspMQkpcEZDrVXeWflPuRzfP/69Pj5GJKCGLP5zstVffYC9lwHP3m5g==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@commercelayer/cli-ux@2.0.0-oclif4.10':
-    resolution: {integrity: sha512-uOtoy2kBXukMJBZhNm75vhrGLTsdqb0gQcbQ88+o0M+clRExMEkrgA2uNPxX3G7NQqSkTk432z/Ok2I8FfRftg==}
+  '@commercelayer/cli-ux@2.0.0-oclif4.11':
+    resolution: {integrity: sha512-pbgf0KKYyDRRY2iQyAHMzUak65pFoDdVz8S4TXr636FaHVi+QWl1D3B8oe4Ak1uno2Ofg98J6SaNE1/dCEGMjQ==}
     engines: {node: '>=22'}
     peerDependencies:
       '@oclif/core': ^4
@@ -1281,8 +1281,8 @@ packages:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
     engines: {node: '>=10'}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -1612,8 +1612,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.325:
-    resolution: {integrity: sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==}
+  electron-to-chromium@1.5.328:
+    resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1879,8 +1879,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -4012,7 +4012,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commercelayer/cli-core@6.0.0-oclif4.9':
+  '@commercelayer/cli-core@6.0.0-oclif4.11':
     dependencies:
       '@commercelayer/js-auth': 7.3.0
       '@oclif/core': 4.10.3
@@ -4022,7 +4022,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@commercelayer/cli-dev@4.0.0-oclif4.5':
+  '@commercelayer/cli-dev@4.0.0-oclif4.6':
     dependencies:
       '@oclif/core': 4.10.3
       fs-extra: 10.1.0
@@ -4031,7 +4031,7 @@ snapshots:
       normalize-package-data: 5.0.0
       tslib: 2.8.1
 
-  '@commercelayer/cli-ux@2.0.0-oclif4.10(@oclif/core@4.10.3)':
+  '@commercelayer/cli-ux@2.0.0-oclif4.11(@oclif/core@4.10.3)':
     dependencies:
       '@oclif/core': 4.10.3
       ansi-escapes: 4.3.2
@@ -5079,7 +5079,7 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  brace-expansion@2.0.2:
+  brace-expansion@2.0.3:
     dependencies:
       balanced-match: 1.0.2
 
@@ -5097,7 +5097,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.11
       caniuse-lite: 1.0.30001781
-      electron-to-chromium: 1.5.325
+      electron-to-chromium: 1.5.328
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
@@ -5317,7 +5317,7 @@ snapshots:
     dependencies:
       '@simple-libs/stream-utils': 1.2.0
       conventional-commits-filter: 5.0.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       meow: 13.2.0
       semver: 7.7.4
 
@@ -5420,7 +5420,7 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.325: {}
+  electron-to-chromium@1.5.328: {}
 
   emoji-regex@10.6.0: {}
 
@@ -5721,7 +5721,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -6194,11 +6194,11 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.0.3
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.0.3
 
   minimist@1.2.8: {}
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -17,13 +17,13 @@ import {
 	clUpdate,
 	clUtil,
 } from "@commercelayer/cli-core"
+import cliux from '@commercelayer/cli-ux'
 import commercelayer, {
 	type CommerceLayerProvisioningClient,
 	CommerceLayerProvisioningStatic,
 	type QueryParams,
 } from "@commercelayer/provisioning-sdk"
-import { Args, Command, ux as cliux, Flags } from "@oclif/core"
-import type { CommandError } from "@oclif/core/lib/interfaces"
+import { Args, Command, Flags, type Interfaces } from "@oclif/core"
 import { exportCsv } from "./csv"
 import {
 	availableLanguages,
@@ -351,7 +351,7 @@ export abstract class BaseFilterCommand extends BaseCommand {
 	}
 
 	// CATCH (override)
-	async catch(error: CommandError): Promise<any> {
+	async catch(error: Interfaces.CommandError): Promise<any> {
 		if (error.message?.match(/Missing \d required args?:\nresource/))
 			this.error(`Missing argument ${clColor.style.error("resource")}`, {
 				suggestions: [

--- a/src/commands/provisioning/create.ts
+++ b/src/commands/provisioning/create.ts
@@ -1,28 +1,24 @@
-import { clApi, clColor } from "@commercelayer/cli-core";
-import type {
-	CommerceLayerProvisioningClient,
-	QueryParamsRetrieve,
-} from "@commercelayer/provisioning-sdk";
-import Command, {
-	Flags /* , FLAG_LOAD_PARAMS, FLAG_SAVE_PARAMS */,
-} from "../../base";
-import { addRequestReader, isRequestInterrupted } from "../../lang";
+import { clApi, clColor } from "@commercelayer/cli-core"
+import type { CommerceLayerProvisioningClient, QueryParamsRetrieve } from "@commercelayer/provisioning-sdk"
+import Command, { Flags /* , FLAG_LOAD_PARAMS, FLAG_SAVE_PARAMS */ } from "../../base"
+import { addRequestReader, isRequestInterrupted } from "../../lang"
 
 // import { mergeCommandParams } from '../../commands'
 
-const OPERATION = "create";
+const OPERATION = "create"
 
 export default class ProvisioningCreate extends Command {
-	static description = "create a new resource";
+	
+	static description = "create a new resource"
 
-	static aliases = ["prov:create", "pc", "pcreate"];
+	static aliases = ["prov:create", "pc", "pcreate"]
 
 	static examples = [
 		"$ commercelayer provisioning:create organizations -a name=MyOrg",
 		"$ clayer prov:create subscriptions -r plan=plans/<planId>",
 		'$ cl prov:create organization -a name=MyOrg -m meta_key="meta value"',
 		"$ cl pc roles -D /path/to/data/file/data.json",
-	];
+	]
 
 	static flags = {
 		...Command.flags,
@@ -58,27 +54,30 @@ export default class ProvisioningCreate extends Command {
 				"doc" /* , FLAG_LOAD_PARAMS, FLAG_SAVE_PARAMS */,
 			],
 		}),
-	};
+	}
 
 	static args = {
 		...Command.args,
-	};
+	}
 
 	async run(): Promise<any> {
-		const { args, flags } = await this.parse(ProvisioningCreate);
 
-		const resource = this.checkResource(args.resource, { singular: true });
+		const { args, flags } = await this.parse(ProvisioningCreate)
+
+		const resource = this.checkResource(args.resource, { singular: true })
 
 		// const loadParams = flags[FLAG_LOAD_PARAMS]
 		// const saveCmd = flags[FLAG_SAVE_PARAMS]
 		// if (saveCmd) this.checkAlias(saveCmd, resource.api, OPERATION, this.config)
-		const showHeaders = flags.headers || flags["headers-only"];
+		const showHeaders = flags.headers || flags["headers-only"]
 
 		// Raw request
 		if (flags.data) {
 			try {
-				const baseUrl = clApi.baseURL("provisioning", undefined, flags.domain);
-				const accessToken = flags.accessToken;
+
+				const baseUrl = clApi.baseURL("provisioning", undefined, flags.domain)
+				const accessToken = flags.accessToken
+
 				const rawRes = await clApi.request.raw(
 					{
 						operation: clApi.Operation.Create,
@@ -87,44 +86,47 @@ export default class ProvisioningCreate extends Command {
 						resource: resource.api,
 					},
 					clApi.request.readDataFile(flags.data),
-				);
-				const out = flags.raw ? rawRes : clApi.response.denormalize(rawRes);
-				this.printOutput(out, flags);
+				)
+				const out = flags.raw ? rawRes : clApi.response.denormalize(rawRes)
+				this.printOutput(out, flags)
 				this.log(
 					`\n${clColor.style.success("Successfully")} created new resource of type ${clColor.style.resource(resource.api)} with id ${clColor.style.id(rawRes.data.id)}\n`,
-				);
-				return out;
+				)
+
+				return out
+
 			} catch (error) {
-				this.printError(error, flags, args);
+				this.printError(error, flags, args)
 			}
+
 		}
 
-		const cl = this.initCommerceLayer(flags);
+		const cl = this.initCommerceLayer(flags)
 
 		// Attributes flags
-		const attributes = this.attributeFlag(flags.attribute);
+		const attributes = this.attributeFlag(flags.attribute)
 		// Objects flags
-		const objects = this.objectFlag(flags.object);
+		const objects = this.objectFlag(flags.object)
 		// Relationships flags
-		const relationships = this.relationshipFlag(flags.relationship);
+		const relationships = this.relationshipFlag(flags.relationship)
 		// Metadata flags
-		const metadata = this.metadataFlag(flags.metadata, { fixTypes: true });
+		const metadata = this.metadataFlag(flags.metadata, { fixTypes: true })
 
 		// Relationships
 		if (relationships && Object.keys(relationships).length > 0)
 			Object.entries(relationships).forEach(([key, value]) => {
 				const relSdk: any =
-					cl[value.type as keyof CommerceLayerProvisioningClient];
-				const rel = relSdk.relationship(value);
-				attributes[key] = rel;
-			});
+					cl[value.type as keyof CommerceLayerProvisioningClient]
+				const rel = relSdk.relationship(value)
+				attributes[key] = rel
+			})
 
 		// Objects
 		if (objects && Object.keys(objects).length > 0) {
 			for (const o of Object.keys(objects)) {
 				if (Object.keys(attributes).includes(o))
-					this.warn(`Object ${o} will overwrite attribute ${o}`);
-				else attributes[o] = objects[o];
+					this.warn(`Object ${o} will overwrite attribute ${o}`)
+				else attributes[o] = objects[o]
 			}
 		}
 
@@ -133,29 +135,29 @@ export default class ProvisioningCreate extends Command {
 			if (attributes.metadata)
 				this.warn(
 					`Attribute ${clColor.style.attribute("metadata")} will be overwritten by the content defined with the flag ${clColor.style.flag("-m")}`,
-				);
-			attributes.metadata = metadata;
+				)
+			attributes.metadata = metadata
 		}
 
 		// Include flags
-		const include: string[] = this.includeFlag(flags.include, relationships);
+		const include: string[] = this.includeFlag(flags.include, relationships)
 		// Fields flags
-		const fields = this.fieldsFlag(flags.fields, resource.type);
+		const fields = this.fieldsFlag(flags.fields, resource.type)
 
 		const rawReader = flags.raw
 			? cl.addRawResponseReader({ headers: showHeaders })
-			: undefined;
-		const reqReader = flags.doc ? addRequestReader(cl) : undefined;
+			: undefined
+		const reqReader = flags.doc ? addRequestReader(cl) : undefined
 
-		const params: QueryParamsRetrieve = {};
+		const params: QueryParamsRetrieve = {}
 
 		try {
 			const resSdk: any =
-				cl[resource.api as keyof CommerceLayerProvisioningClient];
-			this.checkOperation(resSdk, OPERATION);
+				cl[resource.api as keyof CommerceLayerProvisioningClient]
+			this.checkOperation(resSdk, OPERATION)
 
-			if (include && include.length > 0) params.include = include;
-			if (fields && Object.keys(fields).length > 0) params.fields = fields;
+			if (include && include.length > 0) params.include = include
+			if (fields && Object.keys(fields).length > 0) params.fields = fields
 
 			// Load saved command arguments
 			// if (loadParams) {
@@ -163,26 +165,28 @@ export default class ProvisioningCreate extends Command {
 			//   if (savedParams) mergeCommandParams(params, savedParams)
 			// }
 
-			const res = await resSdk.create(attributes, params);
+			const res = await resSdk.create(attributes, params)
 
-			const out = flags.raw && rawReader ? rawReader.rawResponse : res;
+			const out = flags.raw && rawReader ? rawReader.rawResponse : res
 
-			this.printHeaders(rawReader?.headers, flags);
-			this.printOutput(out, flags);
+			this.printHeaders(rawReader?.headers, flags)
+			this.printOutput(out, flags)
 
 			this.log(
 				`\n${clColor.style.success("Successfully")} created new resource of type ${clColor.style.resource(resource.type)} with id ${clColor.style.id(res.id)}\n`,
-			);
+			)
 
 			// Save command arguments
 			// if (saveCmd) this.saveParams(saveCmd, { type: resource.api }, OPERATION, params)
 
-			return out;
+			return out
 		} catch (error) {
 			if (isRequestInterrupted(error) && reqReader) {
-				await this.showLiveDocumentation(reqReader.request, params, flags);
-				cl.removeInterceptor("request", reqReader.id);
-			} else this.printError(error);
+				await this.showLiveDocumentation(reqReader.request, params, flags)
+				cl.removeInterceptor("request", reqReader.id)
+			} else this.printError(error)
 		}
+		
 	}
+
 }

--- a/src/commands/provisioning/delete.ts
+++ b/src/commands/provisioning/delete.ts
@@ -1,19 +1,21 @@
-import { clColor, clCommand } from "@commercelayer/cli-core";
-import type { CommerceLayerProvisioningClient } from "@commercelayer/provisioning-sdk";
-import Command, { Args } from "../../base";
-import { addRequestReader, isRequestInterrupted } from "../../lang";
+import { clColor, clCommand } from "@commercelayer/cli-core"
+import type { CommerceLayerProvisioningClient } from "@commercelayer/provisioning-sdk"
+import Command, { Args } from "../../base"
+import { addRequestReader, isRequestInterrupted } from "../../lang"
 
-const OPERATION = "delete";
+const OPERATION = "delete"
+
 
 export default class ProvisioningDelete extends Command {
-	static description = "delete an existing resource";
 
-	static aliases = ["prov:delete", "pd", "pdelete", "pdel"];
+	static description = "delete an existing resource"
+
+	static aliases = ["prov:delete", "pd", "pdelete", "pdel"]
 
 	static examples = [
 		"$ commercelayer provisioning:delete api_credentials/<id>",
 		"$ cl prov:delete api_credentials <id>",
-	];
+	]
 
 	static flags = {
 		...clCommand.commandFlags(Command.flags, [
@@ -22,7 +24,7 @@ export default class ProvisioningDelete extends Command {
 			"json",
 			"unformatted",
 		]),
-	};
+	}
 
 	static args = {
 		...Command.args,
@@ -31,50 +33,54 @@ export default class ProvisioningDelete extends Command {
 			description: "id of the resource to delete",
 			required: false,
 		}),
-	};
+	}
 
 	async run(): Promise<any> {
-		const { args, flags } = await this.parse(ProvisioningDelete);
 
-		const invalidFlags: string[] = ["fields", "include"];
+		const { args, flags } = await this.parse(ProvisioningDelete)
+
+		const invalidFlags: string[] = ["fields", "include"]
 		invalidFlags.forEach((x) => {
 			if (flags[x as keyof typeof flags])
 				this.error(
 					`Flag not supported in ${clColor.cli.command(OPERATION)} operation: ${clColor.style.error(x)}`,
-				);
-		});
+				)
+		})
 
-		const { res, id } = this.checkResourceId(args.resource, args.id);
+		const { res, id } = this.checkResourceId(args.resource, args.id)
 
-		const resource = this.checkResource(res, { singular: true });
+		const resource = this.checkResource(res, { singular: true })
 
-		const showHeaders = flags.headers || flags["headers-only"];
+		const showHeaders = flags.headers || flags["headers-only"]
 
-		const cl = this.initCommerceLayer(flags);
+		const cl = this.initCommerceLayer(flags)
 
 		const rawReader =
 			flags.raw && showHeaders
 				? cl.addRawResponseReader({ headers: showHeaders })
-				: undefined;
-		const reqReader = flags.doc ? addRequestReader(cl) : undefined;
+				: undefined
+		const reqReader = flags.doc ? addRequestReader(cl) : undefined
 
 		try {
 			const resSdk: any =
-				cl[resource.api as keyof CommerceLayerProvisioningClient];
-			this.checkOperation(resSdk, OPERATION);
+				cl[resource.api as keyof CommerceLayerProvisioningClient]
+			this.checkOperation(resSdk, OPERATION)
 
-			await resSdk.delete(id);
+			await resSdk.delete(id)
 
-			if (showHeaders) this.printHeaders(rawReader?.headers, flags);
+			if (showHeaders) this.printHeaders(rawReader?.headers, flags)
 
 			this.log(
 				`\n${clColor.style.success("Successfully")} deleted resource of type ${clColor.style.resource(resource.type)} with id ${clColor.style.id(id)}\n`,
-			);
+			)
+
 		} catch (error) {
 			if (isRequestInterrupted(error) && reqReader) {
-				await this.showLiveDocumentation(reqReader.request, undefined, flags);
-				cl.removeInterceptor("request", reqReader.id);
-			} else this.printError(error, flags, args);
+				await this.showLiveDocumentation(reqReader.request, undefined, flags)
+				cl.removeInterceptor("request", reqReader.id)
+			} else this.printError(error, flags, args)
 		}
+
 	}
+	
 }

--- a/src/commands/provisioning/exec.ts
+++ b/src/commands/provisioning/exec.ts
@@ -1,16 +1,19 @@
-import { clColor } from "@commercelayer/cli-core";
-import type { CommerceLayerProvisioningClient } from "@commercelayer/provisioning-sdk";
-import Command, { Args, BaseCommand, Flags } from "../../base";
+import { clColor } from "@commercelayer/cli-core"
+import type { CommerceLayerProvisioningClient } from "@commercelayer/provisioning-sdk"
+import Command, { Args, BaseCommand, Flags } from "../../base"
+
+
 
 export default class ProvisioningExec extends BaseCommand {
-	static description = "execute an action on a resource";
 
-	static aliases = ["prov:exec", "pe", "pexec"];
+	static description = "execute an action on a resource"
+
+	static aliases = ["prov:exec", "pe", "pexec"]
 
 	static examples = [
 		"$ commercelayer provisioning:exec organizations <organizationId> transfer_ownership",
 		"$ cl prov:exec memberships <membershipId> resend",
-	];
+	]
 
 	static flags = {
 		attribute: Flags.string({
@@ -18,7 +21,7 @@ export default class ProvisioningExec extends BaseCommand {
 			description: "define a resource attribute",
 			multiple: true,
 		}),
-	};
+	}
 
 	static args = {
 		...Command.args,
@@ -32,41 +35,46 @@ export default class ProvisioningExec extends BaseCommand {
 			description: "action to execute on resource",
 			required: false,
 		}),
-	};
+	}
 
 	public async run(): Promise<void> {
-		const { args, flags } = await this.parse(ProvisioningExec);
-		const action = args.action;
-		if (!action) this.error("Missing action name");
 
-		const { res, id } = this.checkResourceId(args.resource, args.id);
+		const { args, flags } = await this.parse(ProvisioningExec)
+		const action = args.action
+		if (!action) this.error("Missing action name")
 
-		const resource = this.checkResource(res, { singular: true });
+		const { res, id } = this.checkResourceId(args.resource, args.id)
 
-		const clp = this.initCommerceLayer(flags);
+		const resource = this.checkResource(res, { singular: true })
+
+		const clp = this.initCommerceLayer(flags)
 
 		try {
+
 			const resSdk: any =
-				clp[resource.api as keyof CommerceLayerProvisioningClient];
-			this.checkOperation(resSdk, action);
+				clp[resource.api as keyof CommerceLayerProvisioningClient]
+			this.checkOperation(resSdk, action)
 
 			if (resSdk[action].length > 2) {
 				// Base action command has two arguments: resource id and request options
-				const attributes = this.attributeFlag(flags.attribute);
-				await resSdk[action](id, attributes);
+				const attributes = this.attributeFlag(flags.attribute)
+				await resSdk[action](id, attributes)
 			} else {
 				if (flags.attribute && flags.attribute.length > 0)
 					this.warn(
 						`Action ${clColor.cli.arg(action)} does not require argumemts, all the attributes will be ignored.`,
-					);
-				await resSdk[action](id);
+					)
+				await resSdk[action](id)
 			}
+
 		} catch (error) {
 			/*
 			if (isRequestInterrupted(error) && reqReader) {
 				await this.showLiveDocumentation(reqReader.request, undefined, flags)
 				cl.removeInterceptor('request', reqReader.id)
-			} else */ this.printError(error, flags, args);
+			} else */ this.printError(error, flags, args)
 		}
+
 	}
+	
 }

--- a/src/commands/provisioning/fetch.ts
+++ b/src/commands/provisioning/fetch.ts
@@ -1,13 +1,15 @@
-import { Args, BaseFilterCommand } from "../../base";
-import GetCommand from "./get";
-import ListCommand from "./list";
-import RelationshipCommand from "./relationship";
-import RetrieveCommand from "./retrieve";
+import { Args, BaseFilterCommand } from "../../base"
+import GetCommand from "./get"
+import ListCommand from "./list"
+import RelationshipCommand from "./relationship"
+import RetrieveCommand from "./retrieve"
+
 
 export default class ResourcesFetch extends BaseFilterCommand {
-	static description = "retrieve a resource or list a set of resources";
 
-	static aliases = ["prov:fetch", "pf"];
+	static description = "retrieve a resource or list a set of resources"
+
+	static aliases = ["prov:fetch", "pf"]
 
 	static examples = [
 		"$ commercelayer provisioning:fetch roles",
@@ -15,14 +17,14 @@ export default class ResourcesFetch extends BaseFilterCommand {
 		"$ clayer prov:fetch roles/<roleId>",
 		"$ cl prov:fetch roles/<roleId>/<roleRelationship>",
 		"$ cl pf roles/{roleId}/permissions aBcdEkYWx",
-	];
+	]
 
-	static strict = false;
+	static strict = false
 
 	static flags = {
 		...RetrieveCommand.flags,
 		...ListCommand.flags,
-	};
+	}
 
 	static args = {
 		...ListCommand.args,
@@ -36,38 +38,41 @@ export default class ResourcesFetch extends BaseFilterCommand {
 			description: "resource id",
 			required: false,
 		}),
-	};
+	}
 
 	async run(): Promise<any> {
-		const { args } = await this.parse(ResourcesFetch);
 
-		const path = this.fixPath(args.path, args);
-		const id = args.id;
+		const { args } = await this.parse(ResourcesFetch)
+
+		const path = this.fixPath(args.path, args)
+		const id = args.id
 
 		// If no relationship is defined then run retrieve/list command
-		const pathNodes = path.split("/");
-		if (pathNodes.length < 3)
-			return await GetCommand.run(this.argv, this.config);
+		const pathNodes = path.split("/")
+		if (pathNodes.length < 3) return await GetCommand.run(this.argv, this.config)
 
 		// Build argv array to pass to Relationship command
-		const relArgs = [...this.argv];
-		relArgs.splice(0, id ? 2 : 1, ...pathNodes);
+		const relArgs = [...this.argv]
+		relArgs.splice(0, id ? 2 : 1, ...pathNodes)
 
-		return await RelationshipCommand.run(relArgs, this.config);
+		return await RelationshipCommand.run(relArgs, this.config)
 	}
 
 	private fixPath(path: string, args: any, _flags?: any): string {
+
 		// Remove base URL
 		if (path.startsWith("http"))
-			path = path.substring(path.indexOf("/api/") + 4);
+			path = path.substring(path.indexOf("/api/") + 4)
 		// Remove 'relationships' sub-path (usually part of 'self' link)
 		if (path.includes("/relationships/"))
-			path = path.replace("/relationships", "");
+			path = path.replace("/relationships", "")
 		// Remove leading slash
-		if (path.startsWith("/")) path = path.substring(1);
+		if (path.startsWith("/")) path = path.substring(1)
 		// Replace {resourceId} placeholder with actual resource id
-		if (args.id) path = path.replace(/\{.*\}/g, args.id as string);
+		if (args.id) path = path.replace(/\{.*\}/g, args.id as string)
 
-		return path;
+		return path
+
 	}
+	
 }

--- a/src/commands/provisioning/get.ts
+++ b/src/commands/provisioning/get.ts
@@ -1,42 +1,47 @@
-import Command from "../../base";
-import ListCommand from "./list";
-import RetrieveCommand from "./retrieve";
+import Command from "../../base"
+import ListCommand from "./list"
+import RetrieveCommand from "./retrieve"
+
 
 export default class ProvisioningGet extends Command {
-	static description = "retrieve a resource or list a set of resources";
 
-	static aliases = ["prov:get", "pg", "pget"];
+	static description = "retrieve a resource or list a set of resources"
+
+	static aliases = ["prov:get", "pg", "pget"]
 
 	static examples = [
 		"$ commercelayer provisioning:get roles",
 		"$ commercelayer prov:get roles",
 		"$ clayer prov:get roles/<roleId>",
 		"$ cl prov:get roles <roleId>",
-	];
+	]
 
-	static strict = false;
+	static strict = false
 
 	static flags = {
 		...RetrieveCommand.flags,
 		...ListCommand.flags,
-	};
+	}
 
 	static args = {
 		...RetrieveCommand.args,
-	};
+	}
 
 	async run(): Promise<any> {
-		const { args } = await this.parse(ProvisioningGet);
+
+		const { args } = await this.parse(ProvisioningGet)
 
 		const { id, singleton } = this.checkResourceId(
 			args.resource,
 			args.id,
 			false,
-		);
+		)
 
-		const command = id || singleton ? RetrieveCommand : ListCommand;
-		const result = await command.run(this.argv, this.config);
+		const command = id || singleton ? RetrieveCommand : ListCommand
+		const result = await command.run(this.argv, this.config)
 
-		return result;
+		return result
+
 	}
+	
 }

--- a/src/commands/provisioning/list.ts
+++ b/src/commands/provisioning/list.ts
@@ -1,28 +1,23 @@
 // import { mergeCommandParams } from '../../commands'
-import { clColor } from "@commercelayer/cli-core";
-import type {
-	CommerceLayerProvisioningClient,
-	QueryPageSize,
-	QueryParamsList,
-} from "@commercelayer/provisioning-sdk";
-import Command, {
-	cliux,
-	Flags /* FLAG_LOAD_PARAMS, FLAG_SAVE_PARAMS, */,
-} from "../../base";
-import { addRequestReader, isRequestInterrupted } from "../../lang";
+import { clColor } from "@commercelayer/cli-core"
+import type { CommerceLayerProvisioningClient, QueryPageSize, QueryParamsList } from "@commercelayer/provisioning-sdk"
+import Command, { cliux, Flags /* FLAG_LOAD_PARAMS, FLAG_SAVE_PARAMS, */ } from "../../base"
+import { addRequestReader, isRequestInterrupted } from "../../lang"
 
-const OPERATION = "list";
+const OPERATION = "list"
+
 
 export default class ProvisioningList extends Command {
-	static description = "fetch a collection of resources";
 
-	static aliases = ["pl", "prov:list", "plist", "pls"];
+	static description = "fetch a collection of resources"
+
+	static aliases = ["pl", "prov:list", "plist", "pls"]
 
 	static examples = [
 		"$ commercelayer provisioning:list roles -f id,name -i organization -s updated_at",
 		'$ cl prov:list roles -i organization -f name -f organizations/name -w organization_name_eq="ORG NAME"',
 		"$ cl prov:list roles -p 5 -n 10 -s -created_at --raw",
-	];
+	]
 
 	static flags = {
 		...Command.flags,
@@ -70,58 +65,60 @@ export default class ProvisioningList extends Command {
 			dependsOn: ["include"],
 			hidden: true,
 		}),
-	};
+	}
 
 	static args = {
 		...Command.args,
-	};
+	}
+
 
 	async run(): Promise<any> {
-		const { args, flags } = await this.parse(ProvisioningList);
 
-		const resource = this.checkResource(args.resource);
+		const { args, flags } = await this.parse(ProvisioningList)
+
+		const resource = this.checkResource(args.resource)
 
 		// const loadParams = flags[FLAG_LOAD_PARAMS]
 		// const saveCmd = flags[FLAG_SAVE_PARAMS]
 		// if (saveCmd) this.checkAlias(saveCmd, resource.api, OPERATION, this.config)
-		const showHeaders = flags.headers || flags["headers-only"];
+		const showHeaders = flags.headers || flags["headers-only"]
 
 		// Include flags
 		const include: string[] = this.includeFlag(
 			flags.include,
 			undefined,
 			flags["force-include"],
-		);
+		)
 		// Fields flags
-		const fields = this.fieldsFlag(flags.fields, resource.type);
+		const fields = this.fieldsFlag(flags.fields, resource.type)
 		// Where flags
-		const wheres = this.whereFlag(flags.where);
+		const wheres = this.whereFlag(flags.where)
 		// Sort flags
-		const sort = this.sortFlag(flags.sort);
+		const sort = this.sortFlag(flags.sort)
 
-		const page = flags.page;
-		const perPage = flags.pageSize as QueryPageSize;
+		const page = flags.page
+		const perPage = flags.pageSize as QueryPageSize
 
-		const cl = this.initCommerceLayer(flags);
+		const cl = this.initCommerceLayer(flags)
 
 		const rawReader = flags.raw
 			? cl.addRawResponseReader({ headers: showHeaders })
-			: undefined;
-		const reqReader = flags.doc ? addRequestReader(cl) : undefined;
+			: undefined
+		const reqReader = flags.doc ? addRequestReader(cl) : undefined
 
-		const params: QueryParamsList = {};
+		const params: QueryParamsList = {}
 
 		try {
-			const resSdk: any =
-				cl[resource.api as keyof CommerceLayerProvisioningClient];
-			this.checkOperation(resSdk, OPERATION);
 
-			if (include && include.length > 0) params.include = include;
-			if (fields && Object.keys(fields).length > 0) params.fields = fields;
-			if (wheres && Object.keys(wheres).length > 0) params.filters = wheres;
-			if (sort && Object.keys(sort).length > 0) params.sort = sort;
-			if (perPage && perPage > 0) params.pageSize = perPage;
-			if (page && page > 0) params.pageNumber = page;
+			const resSdk: any = cl[resource.api as keyof CommerceLayerProvisioningClient]
+			this.checkOperation(resSdk, OPERATION)
+
+			if (include && include.length > 0) params.include = include
+			if (fields && Object.keys(fields).length > 0) params.fields = fields
+			if (wheres && Object.keys(wheres).length > 0) params.filters = wheres
+			if (sort && Object.keys(sort).length > 0) params.sort = sort
+			if (perPage && perPage > 0) params.pageSize = perPage
+			if (page && page > 0) params.pageNumber = page
 
 			// Load saved command arguments
 			// if (loadParams) {
@@ -130,40 +127,43 @@ export default class ProvisioningList extends Command {
 			// }
 
 			// if (!flags.doc) cliux.action.start(`Fetching ${resource.api.replace(/_/g, ' ')}`)
-			const res = await resSdk.list(params);
-			cliux.action.stop();
+			const res = await resSdk.list(params)
+			cliux.action.stop()
 
-			const out = flags.raw && rawReader ? rawReader.rawResponse : [...res];
-			const meta = res.meta;
+			const out = flags.raw && rawReader ? rawReader.rawResponse : [...res]
+			const meta = res.meta
 
 			if (res && res.length > 0) {
 				if (flags.extract && Array.isArray(out)) {
-					const ext = this.extractFlag(flags.extract);
+					const ext = this.extractFlag(flags.extract)
 					out.forEach((o) => {
-						this.extractObjectFields(ext, o);
-					});
+						this.extractObjectFields(ext, o)
+					})
 				}
 
-				this.printHeaders(rawReader?.headers, flags);
-				this.printOutput(out, flags);
+				this.printHeaders(rawReader?.headers, flags)
+				this.printOutput(out, flags)
 				if (!flags["headers-only"])
 					this.log(
 						`\nRecords: ${clColor.blueBright(res.length)} of ${meta.recordCount} | Page: ${clColor.blueBright(String(flags.page || 1))} of ${meta.pageCount}\n`,
-					);
+					)
 
 				// Save command output
 				// if (flags.save || flags['save-path']) this.saveOutput(out, flags)
-			} else this.log(clColor.italic("\nNo records found\n"));
+			} else this.log(clColor.italic("\nNo records found\n"))
 
 			// Save command arguments
 			// if (saveCmd) this.saveParams(saveCmd, { type: resource.api }, OPERATION, params)
 
-			return out;
+			return out
+
 		} catch (error) {
 			if (isRequestInterrupted(error) && reqReader) {
-				await this.showLiveDocumentation(reqReader.request, params, flags);
-				cl.removeInterceptor("request", reqReader.id);
-			} else this.printError(error, flags, args);
+				await this.showLiveDocumentation(reqReader.request, params, flags)
+				cl.removeInterceptor("request", reqReader.id)
+			} else this.printError(error, flags, args)
 		}
+
 	}
+	
 }

--- a/src/commands/provisioning/noc.ts
+++ b/src/commands/provisioning/noc.ts
@@ -1,15 +1,21 @@
-import { Command } from "@oclif/core";
+import { Command } from "@oclif/core"
 
 export default class Noc extends Command {
-	static hidden = true;
 
-	static flags = {};
+	static hidden = true
+
+	static flags = {}
 
 	async run(): Promise<any> {
-		const output = "-= NoC =-";
 
-		this.log(output);
+		const _parsed = await this.parse(Noc)
 
-		return output;
+		const output = "-= NoC =-"
+
+		this.log(output)
+
+		return output
+
 	}
+
 }

--- a/src/commands/provisioning/relationship.ts
+++ b/src/commands/provisioning/relationship.ts
@@ -1,35 +1,30 @@
-import { clColor, clText } from "@commercelayer/cli-core";
-import type {
-	CommerceLayerProvisioningClient,
-	QueryPageSize,
-	QueryParamsList,
-} from "@commercelayer/provisioning-sdk";
-import Command, {
-	Args,
-	cliux /*, FLAG_LOAD_PARAMS, FLAG_SAVE_PARAMS */,
-} from "../../base";
-import { addRequestReader, isRequestInterrupted } from "../../lang";
+import { clColor, clText } from "@commercelayer/cli-core"
+import type { CommerceLayerProvisioningClient, QueryPageSize, QueryParamsList } from "@commercelayer/provisioning-sdk"
+import Command, { Args, cliux /*, FLAG_LOAD_PARAMS, FLAG_SAVE_PARAMS */ } from "../../base"
+import { addRequestReader, isRequestInterrupted } from "../../lang"
 // import { mergeCommandParams } from '../../commands'
-import ResourcesList from "./list";
+import ResourcesList from "./list"
 
 // const OPERATION = 'relationship'
 
+
 export default class ResourcesRelationship extends Command {
-	static description = "fetch a resource relationship";
 
-	static aliases = ["provisioning:rel", "prov:rel", "prov:relationship"];
+	static description = "fetch a resource relationship"
 
-	static hidden = true;
+	static aliases = ["provisioning:rel", "prov:rel", "prov:relationship"]
+
+	static hidden = true
 
 	static examples = [
 		"$ commercelayer provisioning:relationship roles <roleId> organization",
 		"$ clayer prov:relationship roles <roleId> permissions",
 		"$ cl prov:rel roles <roleId> permisions -w subject_eq=testsub",
-	];
+	]
 
 	static flags = {
 		...ResourcesList.flags,
-	};
+	}
 
 	static args = {
 		...ResourcesList.args,
@@ -43,23 +38,24 @@ export default class ResourcesRelationship extends Command {
 			description: "name of the relationship field",
 			required: true,
 		}),
-	};
+	}
 
 	async run(): Promise<any> {
-		const { args, flags } = await this.parse(ResourcesRelationship);
 
-		const { res: resName, id } = this.checkResourceId(args.resource, args.id);
-		const resource = this.checkResource(resName, { singular: true });
+		const { args, flags } = await this.parse(ResourcesRelationship)
 
-		const relationship = args.relationship;
-		const multiRel = this.isRelationship1N(relationship);
-		const showHeaders = flags.headers || flags["headers-only"];
+		const { res: resName, id } = this.checkResourceId(args.resource, args.id)
+		const resource = this.checkResource(resName, { singular: true })
 
-		const cl = this.initCommerceLayer(flags);
+		const relationship = args.relationship
+		const multiRel = this.isRelationship1N(relationship)
+		const showHeaders = flags.headers || flags["headers-only"]
+
+		const cl = this.initCommerceLayer(flags)
 
 		const resSdk: any =
-			cl[resource.api as keyof CommerceLayerProvisioningClient];
-		this.checkRelationship(resSdk, relationship);
+			cl[resource.api as keyof CommerceLayerProvisioningClient]
+		this.checkRelationship(resSdk, relationship)
 
 		// Load saved args
 		// const loadParams = flags[FLAG_LOAD_PARAMS]
@@ -67,31 +63,32 @@ export default class ResourcesRelationship extends Command {
 		// if (saveCmd) this.checkAlias(saveCmd, resource.api, OPERATION, this.config)
 
 		// Include flags
-		const include: string[] = this.includeFlag(flags.include);
+		const include: string[] = this.includeFlag(flags.include)
 		// Fields flags
-		const fields = this.fieldsFlag(flags.fields, resource.type);
+		const fields = this.fieldsFlag(flags.fields, resource.type)
 		// Where flags
-		const wheres = this.whereFlag(flags.where);
+		const wheres = this.whereFlag(flags.where)
 		// Sort flags
-		const sort = this.sortFlag(flags.sort);
+		const sort = this.sortFlag(flags.sort)
 
-		const page = flags.page;
-		const perPage = flags.pageSize as QueryPageSize;
+		const page = flags.page
+		const perPage = flags.pageSize as QueryPageSize
 
 		const rawReader = flags.raw
 			? cl.addRawResponseReader({ headers: showHeaders })
-			: undefined;
-		const reqReader = flags.doc ? addRequestReader(cl) : undefined;
+			: undefined
+		const reqReader = flags.doc ? addRequestReader(cl) : undefined
 
-		const params: QueryParamsList = {};
+		const params: QueryParamsList = {}
 
 		try {
-			if (include && include.length > 0) params.include = include;
-			if (fields && Object.keys(fields).length > 0) params.fields = fields;
-			if (wheres && Object.keys(wheres).length > 0) params.filters = wheres;
-			if (sort && Object.keys(sort).length > 0) params.sort = sort;
-			if (perPage && perPage > 0) params.pageSize = perPage;
-			if (page && page > 0) params.pageNumber = page;
+
+			if (include && include.length > 0) params.include = include
+			if (fields && Object.keys(fields).length > 0) params.fields = fields
+			if (wheres && Object.keys(wheres).length > 0) params.filters = wheres
+			if (sort && Object.keys(sort).length > 0) params.sort = sort
+			if (perPage && perPage > 0) params.pageSize = perPage
+			if (page && page > 0) params.pageNumber = page
 
 			// Load saved command arguments
 			// if (loadParams) {
@@ -102,25 +99,25 @@ export default class ResourcesRelationship extends Command {
 			if (!flags.doc && multiRel)
 				cliux.action.start(
 					`Fetching ${resource.api.replace(/_/g, " ")}.${relationship} for id ${id}`,
-				);
+				)
 
-			const res = await resSdk[relationship](id, params);
-			if (multiRel) cliux.action.stop();
+			const res = await resSdk[relationship](id, params)
+			if (multiRel) cliux.action.stop()
 
 			const out =
 				flags.raw && rawReader
 					? rawReader.rawResponse
 					: multiRel
 						? [...res]
-						: res;
+						: res
 
 			if (out && flags.extract) {
-				const ext = this.extractFlag(flags.extract);
+				const ext = this.extractFlag(flags.extract)
 				if (Array.isArray(out))
 					out.forEach((o) => {
-						this.extractObjectFields(ext, o);
-					});
-				else this.extractObjectFields(ext, out);
+						this.extractObjectFields(ext, o)
+					})
+				else this.extractObjectFields(ext, out)
 			}
 
 			if (!out || out.length === 0)
@@ -128,14 +125,14 @@ export default class ResourcesRelationship extends Command {
 					clColor.italic(
 						`\nRelationship ${clColor.api.resource(`${resName}.${relationship}`)} is empty\n`,
 					),
-				);
+				)
 			else {
-				this.printHeaders(rawReader?.headers, flags);
-				this.printOutput(out, flags);
+				this.printHeaders(rawReader?.headers, flags)
+				this.printOutput(out, flags)
 				if (multiRel && !flags["headers-only"])
 					this.log(
 						`\nRecords: ${clColor.blueBright(out.length)} of ${res.meta.recordCount} | Page: ${clColor.blueBright(String(flags.page || 1))} of ${res.meta.pageCount}\n`,
-					);
+					)
 				// Save command output
 				// if (flags.save || flags['save-path']) this.saveOutput(out, flags)
 			}
@@ -143,24 +140,31 @@ export default class ResourcesRelationship extends Command {
 			// Save command arguments
 			// if (saveCmd) this.saveParams(saveCmd, { type: resource.api, id }, OPERATION, params)
 
-			return out;
+			return out
+
 		} catch (error) {
 			if (isRequestInterrupted(error) && reqReader) {
-				await this.showLiveDocumentation(reqReader.request, params, flags);
-				cl.removeInterceptor("request", reqReader.id);
-			} else this.printError(error, flags, args);
+				await this.showLiveDocumentation(reqReader.request, params, flags)
+				cl.removeInterceptor("request", reqReader.id)
+			} else this.printError(error, flags, args)
 		}
+
 	}
+
 
 	private checkRelationship(sdk: any, name: string): boolean {
 		if (!sdk[name])
 			this.error(
 				`Relationship not available for resource ${clColor.api.resource(sdk.type())}: ${clColor.msg.error(name)}`,
-			);
-		return true;
+			)
+
+		return true
+
 	}
 
+
 	private isRelationship1N(name: string): boolean {
-		return name === clText.pluralize(name);
+		return name === clText.pluralize(name)
 	}
+	
 }

--- a/src/commands/provisioning/resources.ts
+++ b/src/commands/provisioning/resources.ts
@@ -1,35 +1,35 @@
-import { clColor, clConfig, clUtil } from "@commercelayer/cli-core";
-import { Command, ux as cliux, Flags } from "@oclif/core";
-import type { CommandError } from "@oclif/core/lib/interfaces";
-import { resourceList } from "../../util/resources";
+import { clColor, clConfig, clUtil } from "@commercelayer/cli-core"
+import cliux from "@commercelayer/cli-ux"
+import { Command, Flags } from "@oclif/core"
+import { resourceList } from "../../util/resources"
 
 export default class ProvisioningResources extends Command {
-	static description = "list all the available Provisioning API resources";
+	static description = "list all the available Provisioning API resources"
 
-	static aliases = ["prov:resources", "pres"];
+	static aliases = ["prov:resources", "pres"]
 
 	static examples = [
 		"$ commercelayer provisioning:resources",
 		"$ cl prov:resources",
-	];
+	]
 
 	static flags = {
 		help: Flags.help({ char: "h" }),
-	};
+	}
 
 	async run(): Promise<any> {
-		await this.parse(ProvisioningResources);
+		await this.parse(ProvisioningResources)
 
 		this.log(
 			clColor.style.title("\n-= Provisioning API available resources =-\n"),
-		);
+		)
 
 		const resourceArray = resourceList("api").map((r) => {
 			return {
 				name: r,
 				url: `${clConfig.doc.provisioning_api_reference}/${r}`,
-			};
-		});
+			}
+		})
 
 		cliux.Table.table(
 			resourceArray,
@@ -47,12 +47,12 @@ export default class ProvisioningResources extends Command {
 			{
 				printLine: clUtil.log,
 			},
-		);
-		this.log();
+		)
+		this.log()
 	}
 
 	async catch(error: any): Promise<any> {
-		if (error.code === "EEXIT" && error.message === "EEXIT: 0") return;
-		return await super.catch(error as CommandError);
+		if (error.code === "EEXIT" && error.message === "EEXIT: 0") return
+		return await super.catch(error)
 	}
 }

--- a/src/commands/provisioning/retrieve.ts
+++ b/src/commands/provisioning/retrieve.ts
@@ -1,28 +1,24 @@
-import type {
-	CommerceLayerProvisioningClient,
-	QueryParamsRetrieve,
-} from "@commercelayer/provisioning-sdk";
-import Command, {
-	Args,
-	/*, FLAG_LOAD_PARAMS, FLAG_SAVE_PARAM */ Flags,
-} from "../../base";
-import { addRequestReader, isRequestInterrupted } from "../../lang";
+import type { CommerceLayerProvisioningClient, QueryParamsRetrieve } from "@commercelayer/provisioning-sdk"
+import Command, { Args, /*, FLAG_LOAD_PARAMS, FLAG_SAVE_PARAM */ Flags } from "../../base"
+import { addRequestReader, isRequestInterrupted } from "../../lang"
 
 // import { mergeCommandParams } from '../../commands'
 
-const OPERATION = "retrieve";
+const OPERATION = "retrieve"
+
 
 export default class ProvisioningRetrieve extends Command {
-	static description = "fetch a single resource";
+	
+	static description = "fetch a single resource"
 
-	static aliases = ["prov:retrieve", "pr", "pretrieve"];
+	static aliases = ["prov:retrieve", "pr", "pretrieve"]
 
 	static examples = [
 		"$ commercelayer provisioning:retrieve roles/<roleId>",
 		"$ commercelayer prov:retrieve roles <roleId>",
 		"$ cl prov:retrieve roles <roleId>",
 		"$ clayer pr roles/<roleId>",
-	];
+	]
 
 	static flags = {
 		...Command.flags,
@@ -46,7 +42,7 @@ export default class ProvisioningRetrieve extends Command {
 			multiple: true,
 			exclusive: ["raw"],
 		}),
-	};
+	}
 
 	static args = {
 		...Command.args,
@@ -55,41 +51,43 @@ export default class ProvisioningRetrieve extends Command {
 			description: "id of the resource to retrieve",
 			required: false,
 		}),
-	};
+	}
+
 
 	async run(): Promise<any> {
-		const { args, flags } = await this.parse(ProvisioningRetrieve);
 
-		const { res, id } = this.checkResourceId(args.resource, args.id);
-		const resource = this.checkResource(res, { singular: true });
+		const { args, flags } = await this.parse(ProvisioningRetrieve)
+
+		const { res, id } = this.checkResourceId(args.resource, args.id)
+		const resource = this.checkResource(res, { singular: true })
 
 		// const loadParams = flags[FLAG_LOAD_PARAMS]
 		// const saveCmd = flags[FLAG_SAVE_PARAMS]
 		// if (saveCmd) this.checkAlias(saveCmd, resource.api, OPERATION, this.config)
-		const showHeaders = flags.headers || flags["headers-only"];
+		const showHeaders = flags.headers || flags["headers-only"]
 
 		// Include flags
-		const include: string[] = this.includeFlag(flags.include);
+		const include: string[] = this.includeFlag(flags.include)
 		// Fields flags
-		const fields = this.fieldsFlag(flags.fields, resource.type);
+		const fields = this.fieldsFlag(flags.fields, resource.type)
 
-		const cl = this.initCommerceLayer(flags);
+		const cl = this.initCommerceLayer(flags)
 
 		const rawReader = flags.raw
 			? cl.addRawResponseReader({ headers: showHeaders })
-			: undefined;
-		const reqReader = flags.doc ? addRequestReader(cl) : undefined;
+			: undefined
+		const reqReader = flags.doc ? addRequestReader(cl) : undefined
 
-		const params: QueryParamsRetrieve = {};
+		const params: QueryParamsRetrieve = {}
 
 		try {
-			const resSdk: any =
-				cl[resource.api as keyof CommerceLayerProvisioningClient];
 
-			this.checkOperation(resSdk, OPERATION);
+			const resSdk: any = cl[resource.api as keyof CommerceLayerProvisioningClient]
 
-			if (include && include.length > 0) params.include = include;
-			if (fields && Object.keys(fields).length > 0) params.fields = fields;
+			this.checkOperation(resSdk, OPERATION)
+
+			if (include && include.length > 0) params.include = include
+			if (fields && Object.keys(fields).length > 0) params.fields = fields
 
 			// Load saved command arguments
 			// if (loadParams) {
@@ -97,29 +95,32 @@ export default class ProvisioningRetrieve extends Command {
 			//   if (savedParams) mergeCommandParams(params, savedParams)
 			//  }
 
-			const res = await resSdk.retrieve(id, params);
+			const res = await resSdk.retrieve(id, params)
 
-			const out = flags.raw && rawReader ? rawReader.rawResponse : res;
+			const out = flags.raw && rawReader ? rawReader.rawResponse : res
 
 			if (flags.extract) {
-				const ext = this.extractFlag(flags.extract);
-				this.extractObjectFields(ext, out);
+				const ext = this.extractFlag(flags.extract)
+				this.extractObjectFields(ext, out)
 			}
 
-			this.printHeaders(rawReader?.headers, flags);
-			this.printOutput(out, flags);
+			this.printHeaders(rawReader?.headers, flags)
+			this.printOutput(out, flags)
 
 			// Save command output
 			// if (flags.save || flags['save-path']) this.saveOutput(out, flags)
 			// Save command arguments
 			// if (saveCmd) this.saveParams(saveCmd, { type: resource.api, id }, OPERATION, params)
 
-			return out;
+			return out
+
 		} catch (error: any) {
 			if (isRequestInterrupted(error) && reqReader) {
-				await this.showLiveDocumentation(reqReader.request, params, flags);
-				cl.removeInterceptor("request", reqReader.id);
-			} else this.printError(error, flags, args);
+				await this.showLiveDocumentation(reqReader.request, params, flags)
+				cl.removeInterceptor("request", reqReader.id)
+			} else this.printError(error, flags, args)
 		}
+
 	}
+	
 }

--- a/src/commands/provisioning/update.ts
+++ b/src/commands/provisioning/update.ts
@@ -1,20 +1,16 @@
-import { clApi, clColor } from "@commercelayer/cli-core";
-import type {
-	CommerceLayerProvisioningClient,
-	QueryParamsRetrieve,
-} from "@commercelayer/provisioning-sdk";
-import Command, {
-	Args,
-	/* , FLAG_LOAD_PARAMS, FLAG_SAVE_PARAMS */ Flags,
-} from "../../base";
-import { addRequestReader, isRequestInterrupted } from "../../lang";
+import { clApi, clColor } from "@commercelayer/cli-core"
+import type { CommerceLayerProvisioningClient, QueryParamsRetrieve } from "@commercelayer/provisioning-sdk"
+import Command, { Args, /* , FLAG_LOAD_PARAMS, FLAG_SAVE_PARAMS */ Flags } from "../../base"
+import { addRequestReader, isRequestInterrupted } from "../../lang"
 
-const OPERATION = "update";
+const OPERATION = "update"
+
 
 export default class ProvisioningUpdate extends Command {
-	static description = "update an existing resource";
 
-	static aliases = ["prov:update", "pu", "pupdate", "pupd"];
+	static description = "update an existing resource"
+
+	static aliases = ["prov:update", "pu", "pupdate", "pupd"]
 
 	static examples = [
 		"$ commercelayer provisioning:update roles/<roleId> -a reference=referenceId",
@@ -22,7 +18,7 @@ export default class ProvisioningUpdate extends Command {
 		'$ cl prov:update roles/<roleId> -m meta_key="meta value"',
 		'$ cl pu roles <roleId> -M meta_key="metadata overwrite',
 		"$ clayer prov:update roles <roleId> -D /path/to/data/file/data.json",
-	];
+	]
 
 	static flags = {
 		...Command.flags,
@@ -67,7 +63,7 @@ export default class ProvisioningUpdate extends Command {
 				"doc" /*, FLAG_LOAD_PARAMS, FLAG_SAVE_PARAMS */,
 			],
 		}),
-	};
+	}
 
 	static args = {
 		...Command.args,
@@ -76,24 +72,27 @@ export default class ProvisioningUpdate extends Command {
 			description: "id of the resource to update",
 			required: false,
 		}),
-	};
+	}
+
 
 	async run(): Promise<any> {
-		const { args, flags } = await this.parse(ProvisioningUpdate);
 
-		const { res, id } = this.checkResourceId(args.resource, args.id);
-		const resource = this.checkResource(res, { singular: true });
+		const { args, flags } = await this.parse(ProvisioningUpdate)
+
+		const { res, id } = this.checkResourceId(args.resource, args.id)
+		const resource = this.checkResource(res, { singular: true })
 
 		// const loadParams = flags[FLAG_LOAD_PARAMS]
 		// const saveCmd = flags[FLAG_SAVE_PARAMS]
 		// if (saveCmd) this.checkAlias(saveCmd, resource.api, OPERATION, this.config)
-		const showHeaders = flags.headers || flags["headers-only"];
+		const showHeaders = flags.headers || flags["headers-only"]
 
 		// Raw request
 		if (flags.data) {
 			try {
-				const baseUrl = clApi.baseURL("provisioning", undefined, flags.domain);
-				const accessToken = flags.accessToken;
+
+				const baseUrl = clApi.baseURL("provisioning", undefined, flags.domain)
+				const accessToken = flags.accessToken
 				const rawRes = await clApi.request.raw(
 					{
 						operation: clApi.Operation.Update,
@@ -103,48 +102,51 @@ export default class ProvisioningUpdate extends Command {
 					},
 					clApi.request.readDataFile(flags.data),
 					id,
-				);
-				const out = flags.raw ? rawRes : clApi.response.denormalize(rawRes);
-				this.printOutput(out, flags);
+				)
+				const out = flags.raw ? rawRes : clApi.response.denormalize(rawRes)
+				this.printOutput(out, flags)
 				this.log(
 					`\n${clColor.style.success("Successfully")} updated resource of type ${clColor.style.resource(resource.api)} with id ${clColor.style.id(rawRes.id)}\n`,
-				);
-				return out;
+				)
+
+				return out
+
 			} catch (error) {
-				this.printError(error);
+				this.printError(error)
 			}
+
 		}
 
-		const cl = this.initCommerceLayer(flags);
+		const cl = this.initCommerceLayer(flags)
 
 		// Attributes flags
-		const attributes = this.attributeFlag(flags.attribute);
+		const attributes = this.attributeFlag(flags.attribute)
 		// Objects flags
-		const objects = this.objectFlag(flags.object);
+		const objects = this.objectFlag(flags.object)
 		// Relationships flags
-		const relationships = this.relationshipFlag(flags.relationship);
+		const relationships = this.relationshipFlag(flags.relationship)
 		// Metadata flags
 		const metadata = this.metadataFlag(
 			flags.metadata || flags["metadata-replace"],
-		);
+		)
 
 		// Relationships
 		if (relationships && Object.keys(relationships).length > 0)
 			Object.entries(relationships).forEach(([key, value]) => {
 				const relSdk: any =
-					cl[value.type as keyof CommerceLayerProvisioningClient];
+					cl[value.type as keyof CommerceLayerProvisioningClient]
 				const rel = relSdk.relationship(
 					value.id === null || value.id === "null" ? null : value,
-				);
-				attributes[key] = rel;
-			});
+				)
+				attributes[key] = rel
+			})
 
 		// Objects
 		if (objects && Object.keys(objects).length > 0) {
 			for (const o of Object.keys(objects)) {
 				if (Object.keys(attributes).includes(o))
-					this.warn(`Object ${o} will overwrite attribute ${o}`);
-				else attributes[o] = objects[o];
+					this.warn(`Object ${o} will overwrite attribute ${o}`)
+				else attributes[o] = objects[o]
 			}
 		}
 
@@ -153,42 +155,42 @@ export default class ProvisioningUpdate extends Command {
 			if (attributes.metadata)
 				this.warn(
 					`Attribute ${clColor.style.attribute("metadata")} will be overwritten by the content defined with the flags ${clColor.style.flag("-m/-M")}`,
-				);
-			attributes.metadata = metadata;
+				)
+			attributes.metadata = metadata
 		}
 
 		// Include flags
-		const include: string[] = this.includeFlag(flags.include, relationships);
+		const include: string[] = this.includeFlag(flags.include, relationships)
 		// Fields flags
-		const fields = this.fieldsFlag(flags.fields, resource.type);
+		const fields = this.fieldsFlag(flags.fields, resource.type)
 
 		const rawReader = flags.raw
 			? cl.addRawResponseReader({ headers: showHeaders })
-			: undefined;
-		const reqReader = flags.doc ? addRequestReader(cl) : undefined;
+			: undefined
+		const reqReader = flags.doc ? addRequestReader(cl) : undefined
 
-		const params: QueryParamsRetrieve = {};
+		const params: QueryParamsRetrieve = {}
 
 		try {
-			const resSdk: any =
-				cl[resource.api as keyof CommerceLayerProvisioningClient];
-			this.checkOperation(resSdk, OPERATION, attributes);
 
-			if (include && include.length > 0) params.include = include;
-			if (fields && Object.keys(fields).length > 0) params.fields = fields;
+			const resSdk: any = cl[resource.api as keyof CommerceLayerProvisioningClient]
+			this.checkOperation(resSdk, OPERATION, attributes)
+
+			if (include && include.length > 0) params.include = include
+			if (fields && Object.keys(fields).length > 0) params.fields = fields
 
 			// Metadata attributes merge
 			if (flags.metadata) {
 				const params: QueryParamsRetrieve = {
 					fields: { [resource.api]: ["metadata"] },
-				};
-				const remRes = await resSdk.retrieve(id, params);
-				const remMeta: object = remRes.metadata;
+				}
+				const remRes = await resSdk.retrieve(id, params)
+				const remMeta: object = remRes.metadata
 				if (remMeta && Object.keys(remMeta).length > 0)
-					attributes.metadata = { ...remMeta, ...metadata };
+					attributes.metadata = { ...remMeta, ...metadata }
 			}
 
-			attributes.id = id;
+			attributes.id = id
 
 			// Load saved command arguments
 			// if (loadParams) {
@@ -196,26 +198,29 @@ export default class ProvisioningUpdate extends Command {
 			//   if (savedParams) mergeCommandParams(params, savedParams)
 			// }
 
-			const res = await resSdk.update(attributes, params);
+			const res = await resSdk.update(attributes, params)
 
-			const out = flags.raw && rawReader ? rawReader.rawResponse : res;
+			const out = flags.raw && rawReader ? rawReader.rawResponse : res
 
-			this.printHeaders(rawReader?.headers, flags);
-			this.printOutput(out, flags);
+			this.printHeaders(rawReader?.headers, flags)
+			this.printOutput(out, flags)
 
 			this.log(
 				`\n${clColor.style.success("Successfully")} updated resource of type ${clColor.style.resource(resource.type)} with id ${clColor.style.id(res.id)}\n`,
-			);
+			)
 
 			// Save command arguments
 			// if (saveCmd) this.saveParams(saveCmd, { type: resource.api }, OPERATION, params)
 
-			return out;
+			return out
+
 		} catch (error) {
 			if (isRequestInterrupted(error) && reqReader) {
-				await this.showLiveDocumentation(reqReader.request, undefined, flags);
-				cl.removeInterceptor("request", reqReader.id);
-			} else this.printError(error, flags, args);
+				await this.showLiveDocumentation(reqReader.request, undefined, flags)
+				cl.removeInterceptor("request", reqReader.id)
+			} else this.printError(error, flags, args)
 		}
+
 	}
+	
 }

--- a/test/commands/provisioning/create.test.ts
+++ b/test/commands/provisioning/create.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from "@oclif/test";
+import { runCommand } from '@oclif/test'
+import { expect } from 'chai'
 
-describe("provisioning:create", () => {
-	test
-		.timeout(15000)
-		.stdout()
-		.command(["provisioning:noc"])
-		.it("runs NoC", (ctx) => {
-			expect(ctx.stdout).to.contain("-= NoC =-");
-		});
-});
+
+describe('provisioning:create', () => {
+  it('runs NoC', async () => {
+    const { stdout } = await runCommand<{ name: string }>(['provisioning:noc'])
+    expect(stdout).to.contain('-= NoC =-')
+  }).timeout(15000)
+})

--- a/test/commands/provisioning/delete.test.ts
+++ b/test/commands/provisioning/delete.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from "@oclif/test";
+import { runCommand } from '@oclif/test'
+import { expect } from 'chai'
 
-describe("provisioning:delete", () => {
-	test
-		.timeout(15000)
-		.stdout()
-		.command(["provisioning:noc"])
-		.it("runs NoC", (ctx) => {
-			expect(ctx.stdout).to.contain("-= NoC =-");
-		});
-});
+
+describe('provisioning:delete', () => {
+  it('runs NoC', async () => {
+    const { stdout } = await runCommand<{ name: string }>(['provisioning:noc'])
+    expect(stdout).to.contain('-= NoC =-')
+  }).timeout(15000)
+})

--- a/test/commands/provisioning/exec.test.ts
+++ b/test/commands/provisioning/exec.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from "@oclif/test";
+import { runCommand } from '@oclif/test'
+import { expect } from 'chai'
 
-describe("provisioning:exec", () => {
-	test
-		.timeout(15000)
-		.stdout()
-		.command(["provisioning:noc"])
-		.it("runs NoC", (ctx) => {
-			expect(ctx.stdout).to.contain("-= NoC =-");
-		});
-});
+
+describe('provisioning:exec', () => {
+  it('runs NoC', async () => {
+    const { stdout } = await runCommand<{ name: string }>(['provisioning:noc'])
+    expect(stdout).to.contain('-= NoC =-')
+  }).timeout(15000)
+})

--- a/test/commands/provisioning/fetch.test.ts
+++ b/test/commands/provisioning/fetch.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from "@oclif/test";
+import { runCommand } from '@oclif/test'
+import { expect } from 'chai'
 
-describe("provisioning:fetch", () => {
-	test
-		.timeout(15000)
-		.stdout()
-		.command(["provisioning:noc"])
-		.it("runs NoC", (ctx) => {
-			expect(ctx.stdout).to.contain("-= NoC =-");
-		});
-});
+
+describe('provisioning:fetch', () => {
+  it('runs NoC', async () => {
+    const { stdout } = await runCommand<{ name: string }>(['provisioning:noc'])
+    expect(stdout).to.contain('-= NoC =-')
+  }).timeout(15000)
+})

--- a/test/commands/provisioning/get.test.ts
+++ b/test/commands/provisioning/get.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from "@oclif/test";
+import { runCommand } from '@oclif/test'
+import { expect } from 'chai'
 
-describe("provisioning:get", () => {
-	test
-		.timeout(15000)
-		.stdout()
-		.command(["provisioning:noc"])
-		.it("runs NoC", (ctx) => {
-			expect(ctx.stdout).to.contain("-= NoC =-");
-		});
-});
+
+describe('provisioning:get', () => {
+  it('runs NoC', async () => {
+    const { stdout } = await runCommand<{ name: string }>(['provisioning:noc'])
+    expect(stdout).to.contain('-= NoC =-')
+  }).timeout(15000)
+})

--- a/test/commands/provisioning/list.test.ts
+++ b/test/commands/provisioning/list.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from "@oclif/test";
+import { runCommand } from '@oclif/test'
+import { expect } from 'chai'
 
-describe("provisioning:list", () => {
-	test
-		.timeout(15000)
-		.stdout()
-		.command(["provisioning:noc"])
-		.it("runs NoC", (ctx) => {
-			expect(ctx.stdout).to.contain("-= NoC =-");
-		});
-});
+
+describe('provisioning:list', () => {
+  it('runs NoC', async () => {
+    const { stdout } = await runCommand<{ name: string }>(['provisioning:noc'])
+    expect(stdout).to.contain('-= NoC =-')
+  }).timeout(15000)
+})

--- a/test/commands/provisioning/relationship.test.ts
+++ b/test/commands/provisioning/relationship.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from "@oclif/test";
+import { runCommand } from '@oclif/test'
+import { expect } from 'chai'
 
-describe("provisioning:relationship", () => {
-	test
-		.timeout(15000)
-		.stdout()
-		.command(["provisioning:noc"])
-		.it("runs NoC", (ctx) => {
-			expect(ctx.stdout).to.contain("-= NoC =-");
-		});
-});
+
+describe('provisioning:relationship', () => {
+  it('runs NoC', async () => {
+    const { stdout } = await runCommand<{ name: string }>(['provisioning:noc'])
+    expect(stdout).to.contain('-= NoC =-')
+  }).timeout(15000)
+})

--- a/test/commands/provisioning/resources.test.ts
+++ b/test/commands/provisioning/resources.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from "@oclif/test";
+import { runCommand } from '@oclif/test'
+import { expect } from 'chai'
 
-describe("provisioning:resources", () => {
-	test
-		.timeout(15000)
-		.stdout()
-		.command(["provisioning:noc"])
-		.it("runs NoC", (ctx) => {
-			expect(ctx.stdout).to.contain("-= NoC =-");
-		});
-});
+
+describe('provisioning:resources', () => {
+  it('runs NoC', async () => {
+    const { stdout } = await runCommand<{ name: string }>(['provisioning:noc'])
+    expect(stdout).to.contain('-= NoC =-')
+  }).timeout(15000)
+})

--- a/test/commands/provisioning/retrieve.test.ts
+++ b/test/commands/provisioning/retrieve.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from "@oclif/test";
+import { runCommand } from '@oclif/test'
+import { expect } from 'chai'
 
-describe("provisioning:retrieve", () => {
-	test
-		.timeout(15000)
-		.stdout()
-		.command(["provisioning:noc"])
-		.it("runs NoC", (ctx) => {
-			expect(ctx.stdout).to.contain("-= NoC =-");
-		});
-});
+
+describe('provisioning:retrieve', () => {
+  it('runs NoC', async () => {
+    const { stdout } = await runCommand<{ name: string }>(['provisioning:noc'])
+    expect(stdout).to.contain('-= NoC =-')
+  }).timeout(15000)
+})

--- a/test/commands/provisioning/update.test.ts
+++ b/test/commands/provisioning/update.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from "@oclif/test";
+import { runCommand } from '@oclif/test'
+import { expect } from 'chai'
 
-describe("provisioning:update", () => {
-	test
-		.timeout(15000)
-		.stdout()
-		.command(["provisioning:noc"])
-		.it("runs NoC", (ctx) => {
-			expect(ctx.stdout).to.contain("-= NoC =-");
-		});
-});
+
+describe('provisioning:update', () => {
+  it('runs NoC', async () => {
+    const { stdout } = await runCommand<{ name: string }>(['provisioning:noc'])
+    expect(stdout).to.contain('-= NoC =-')
+  }).timeout(15000)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
 		"strict": true,
 		"target": "ES2022",
 		"esModuleInterop": true,
-		"resolveJsonModule": true
+		"resolveJsonModule": true,
+		"types": ["node"]
 	},
 	"include": ["src/**/*"]
 }


### PR DESCRIPTION
### Changes

- **oclif core v4**: Upgrades `@oclif/core` from `^3.27.0` to `^4.11.0` and `@oclif/test` from `^3.x` to `^4.x`
- **Internal packages**: Switches `@commercelayer/cli-core` and `@commercelayer/cli-dev` to `oclif4` channel; adds `@commercelayer/cli-ux` (oclif4) as an explicit dependency — `ux as cliux` was previously pulled from `@oclif/core` directly
- **Node requirement**: Bumps minimum Node.js engine from `>=20` to `>=22`
- **Type imports**: Replaces the removed `CommandError` import from `@oclif/core/lib/interfaces` with `Interfaces.CommandError` from `@oclif/core`
- **Test syntax**: Migrates all test files from the old `test.stdout().command().it()` chain to the new `runCommand` + async/await pattern from `@oclif/test` v4
- **`noc` command**: Adds required `this.parse(Noc)` call to satisfy oclif v4's stricter command lifecycle
- **Code style**: Removes trailing semicolons across all command files, consistent with the Biome formatter config applied to this package
- **tsconfig**: Adds explicit `"types": ["node"]` to compiler options
- **Release config**: Adds `oclif` branch as a prerelease channel in `.releaserc`
